### PR TITLE
 Build scripts now use a single cache at /Users/alazarshenkute/.cache…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,53 @@
+# Normalize line endings on commit and force LF on checkout for everything
+# that must run on Unix toolchains (Android NDK, bash, python, cmake).
+# Without this, a contributor on Windows with core.autocrlf=true will
+# silently CRLF-ify *.sh on checkout and bash will refuse to run them.
+
+* text=auto eol=lf
+
+# Shell + python + build files: hard-pin LF, override any autocrlf.
+*.sh        text eol=lf
+*.bash      text eol=lf
+*.py        text eol=lf
+*.cmake     text eol=lf
+CMakeLists.txt text eol=lf
+Makefile    text eol=lf
+*.mk        text eol=lf
+
+# Source code: LF.
+*.c         text eol=lf
+*.h         text eol=lf
+*.cpp       text eol=lf
+*.hpp       text eol=lf
+*.cl        text eol=lf
+
+# Docs + config: LF.
+*.md        text eol=lf
+*.json      text eol=lf
+*.yaml      text eol=lf
+*.yml       text eol=lf
+*.toml      text eol=lf
+*.cfg       text eol=lf
+*.ini       text eol=lf
+.gitignore  text eol=lf
+.gitattributes text eol=lf
+LICENSE     text eol=lf
+
+# Binary: never touched by autocrlf, never normalized.
+*.bin       binary
+*.so        binary
+*.a         binary
+*.dylib     binary
+*.dll       binary
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.webp      binary
+*.mp4       binary
+*.mov       binary
+*.gz        binary
+*.tar       binary
+*.tgz       binary
+*.zip       binary
+*.safetensors binary

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # adreno-llms 📱⚡
 
-### ⚡ Lightning-fast inference on Adreno ⚡
+### ⚡ Lightning-fast inference on Qualcomm Adreno 6xx GPUs ⚡
 
 > All code in this repo was ported and optimized by **NNOpt** — a coding agent for porting and optimizing neural networks for Android embedded targets. **Contact a8nova@gmail.com for early access.**
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Decode tok/s = 5-run warm median, fp16, greedy, 32-token generation, measured 20
 ## 🚀 Quickstart
 
 ```bash
-git clone https://github.com/<you>/adreno-llms.git
+git clone https://github.com/a8nova/adreno-llms.git
 cd adreno-llms
 
 # Pick any model — example: SmolLM2-135M-Instruct
@@ -65,7 +65,7 @@ Tokens stream to stdout as they decode.
 |---|---|---|
 | Android NDK | r25+ (any recent) | `sdkmanager 'ndk;26.1.10909125'` or Android Studio SDK Manager |
 | CMake | 3.18+ | `brew install cmake` |
-| OpenCL headers | 1.2 (Khronos) | Auto-fetched by build into `~/.nnopt/deps/opencl/` |
+| OpenCL headers + Android `libOpenCL.so` link stub | Khronos | Run `scripts/setup_deps.sh` once — downloads headers and pulls `libOpenCL.so` from your connected device into `~/.cache/adreno-llms/` |
 | CLBlast | 1.6.3 | Pinned via CMake `FetchContent` — built on first `build.sh` |
 | Python | 3.10+ | For tokenizer parity checks |
 | `adb` | platform-tools | `brew install --cask android-platform-tools` |

--- a/scripts/setup_deps.sh
+++ b/scripts/setup_deps.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# One-time dependency setup for adreno-llms.
+#
+# Downloads:
+#   1. Khronos OpenCL C headers (CL/cl.h, etc.) into the local cache.
+#   2. libOpenCL.so from a connected Android device (used as a link-time
+#      stub so the inference binary can link against the device's vendor
+#      OpenCL ICD; the actual runtime lookup happens via dlopen on device).
+#
+# Cache lives at:
+#   ${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}/opencl/
+#
+# Idempotent — re-running is a no-op once both items are present.
+#
+# CLBlast is NOT downloaded here — each model's CMakeLists.txt fetches +
+# builds CLBlast 1.6.3 from source via FetchContent on first cmake configure.
+
+set -euo pipefail
+
+CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_DIR="${CACHE}/opencl"
+HEADERS_DIR="${OPENCL_DIR}/include/CL"
+LIB_DIR="${OPENCL_DIR}/lib/android-arm64-v8a"
+LIBCL="${LIB_DIR}/libOpenCL.so"
+
+HEADERS_TAG="${OPENCL_HEADERS_TAG:-v2024.10.24}"
+HEADERS_URL="https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/${HEADERS_TAG}.tar.gz"
+
+mkdir -p "${HEADERS_DIR}" "${LIB_DIR}"
+
+# ── 1. OpenCL headers ───────────────────────────────────────────────────
+echo ">>> [1/2] OpenCL headers (Khronos ${HEADERS_TAG})"
+if [ -f "${HEADERS_DIR}/cl.h" ]; then
+    echo "    already present at ${HEADERS_DIR}/cl.h"
+else
+    echo "    downloading ${HEADERS_URL}"
+    TMP=$(mktemp -d)
+    trap 'rm -rf "${TMP}"' EXIT
+    curl --location --fail-with-body --silent --output "${TMP}/headers.tar.gz" "${HEADERS_URL}"
+    tar -xzf "${TMP}/headers.tar.gz" -C "${TMP}"
+    SRC_HEADERS_DIR="${TMP}/OpenCL-Headers-${HEADERS_TAG#v}/CL"
+    if [ ! -d "${SRC_HEADERS_DIR}" ]; then
+        echo "    ERROR: extracted tarball doesn't contain CL/ directory at ${SRC_HEADERS_DIR}" >&2
+        exit 1
+    fi
+    cp "${SRC_HEADERS_DIR}"/*.h "${HEADERS_DIR}/"
+    echo "    installed $(ls "${HEADERS_DIR}" | wc -l | tr -d ' ') headers to ${HEADERS_DIR}"
+    trap - EXIT
+    rm -rf "${TMP}"
+fi
+
+# ── 2. Android libOpenCL.so (link stub) ─────────────────────────────────
+echo ""
+echo ">>> [2/2] Android libOpenCL.so (link stub, pulled from a connected device)"
+if [ -f "${LIBCL}" ]; then
+    echo "    already present at ${LIBCL}"
+else
+    if ! command -v adb >/dev/null 2>&1; then
+        echo "    ERROR: adb not in PATH" >&2
+        echo "    install android-platform-tools, or manually copy any" >&2
+        echo "    Android arm64-v8a libOpenCL.so to ${LIBCL}" >&2
+        exit 1
+    fi
+    if [ "$(adb devices | tail -n +2 | grep -c 'device$')" -eq 0 ]; then
+        echo "    ERROR: no Android device connected via adb" >&2
+        echo "    connect your target device and re-run, or copy a libOpenCL.so to:" >&2
+        echo "      ${LIBCL}" >&2
+        exit 1
+    fi
+    PULLED=""
+    for path in /vendor/lib64/libOpenCL.so /system/vendor/lib64/libOpenCL.so /system/lib64/libOpenCL.so; do
+        if adb shell "[ -f ${path} ]" 2>/dev/null; then
+            echo "    pulling from device: ${path}"
+            adb pull "${path}" "${LIBCL}" >/dev/null 2>&1 && PULLED="1"
+            break
+        fi
+    done
+    if [ -z "${PULLED}" ] || [ ! -f "${LIBCL}" ]; then
+        echo "    ERROR: libOpenCL.so not found on device at any standard path" >&2
+        echo "    standard paths checked: /vendor/lib64, /system/vendor/lib64, /system/lib64" >&2
+        exit 1
+    fi
+    echo "    saved $(stat -f%z "${LIBCL}" 2>/dev/null || stat -c%s "${LIBCL}") bytes to ${LIBCL}"
+fi
+
+echo ""
+echo "Deps ready at ${OPENCL_DIR}"

--- a/src/models/lfm2-5-350m/CMakeLists.txt
+++ b/src/models/lfm2-5-350m/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ANDROID)
 endif()
 
 # CLBlast backend
-# OpenCL headers from ~/.nnopt/deps/ (downloaded by porting orchestrator)
+# OpenCL headers from $HOME/.cache/adreno-llms/opencl/include (downloaded by scripts/setup_deps.sh).
 # These are Khronos headers with an OpenCL/ symlink for macOS compatibility
 if(DEFINED OPENCL_INCLUDE_DIR)
     message(STATUS "Using OpenCL headers from: ${OPENCL_INCLUDE_DIR}")
@@ -107,11 +107,11 @@ endif()
 # Include our Khronos headers for all project code (BEFORE ensures priority over system paths)
 include_directories(BEFORE ${OPENCL_INCLUDE_DIR})
 
-# CLBlast — prefer pre-built from ~/.nnopt/deps/clblast/, fall back to FetchContent.
+# CLBlast — built from source via CMake FetchContent (no system install needed).
 # Under fp16, SKIP the pre-built artifact: it's typically built without HALF=ON
 # (Hgemm symbol absent), and a silent Sgemm fallback would defeat the whole
 # point of the fp16 build. Always FetchContent + rebuild with HALF=ON for fp16.
-set(NNOPT_CLBLAST_DIR "$ENV{HOME}/.nnopt/deps/clblast")
+set(NNOPT_CLBLAST_DIR "$ENV{NNOPT_CLBLAST_DIR}")
 set(_NNOPT_USE_PREBUILT_CLBLAST FALSE)
 if(NOT NNOPT_DTYPE STREQUAL "fp16"
    AND EXISTS "${NNOPT_CLBLAST_DIR}/lib/libclblast.a"

--- a/src/models/lfm2-5-350m/scripts/build.sh
+++ b/src/models/lfm2-5-350m/scripts/build.sh
@@ -101,23 +101,38 @@ echo "Target ABI: arm64-v8a"
 echo "Target API Level: 21"
 
 # ============================================
-# Check OpenCL headers (downloaded by porting orchestrator)
-# CLBlast is built from source via CMake FetchContent
+# Check OpenCL headers + libOpenCL.so link stub.
+#
+# Cache lives at $HOME/.cache/adreno-llms/ (override with $ADRENO_LLMS_CACHE).
+# If headers are missing, scripts/setup_deps.sh is invoked automatically — it
+# downloads the Khronos OpenCL headers and pulls libOpenCL.so from a connected
+# Android device. CLBlast is built from source via CMake FetchContent on first
+# configure.
 # ============================================
-DEPS_DIR="$HOME/.nnopt/deps"
-OPENCL_INC="$DEPS_DIR/opencl/include"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_INC="$ADRENO_LLMS_CACHE/opencl/include"
+OPENCL_LIB_DIR="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a"
 
 if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
-    echo "ERROR: OpenCL headers not found at $OPENCL_INC"
-    echo "The porting orchestrator should have downloaded these."
+    SETUP_SH="$(cd "$(dirname "$0")/../../../../scripts" && pwd)/setup_deps.sh"
+    if [ -x "$SETUP_SH" ]; then
+        echo "OpenCL deps not found in $ADRENO_LLMS_CACHE — running setup_deps.sh"
+        bash "$SETUP_SH"
+    else
+        echo "ERROR: OpenCL headers not found and setup_deps.sh missing at $SETUP_SH" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
+    echo "ERROR: OpenCL headers still not found at $OPENCL_INC after setup" >&2
     exit 1
 fi
 
 echo "Using OpenCL headers: $OPENCL_INC"
 echo "CLBlast will be built from source via CMake FetchContent"
 
-# Check for extracted OpenCL library (used as stub for linking)
-OPENCL_LIB_DIR="$DEPS_DIR/opencl/lib/android-arm64-v8a"
+# Check for extracted OpenCL library (used as link-time stub).
 OPENCL_LIB="$OPENCL_LIB_DIR/libOpenCL.so"
 CMAKE_OPENCL_ARG=""
 

--- a/src/models/lfm2-5-350m/scripts/deploy_android.sh
+++ b/src/models/lfm2-5-350m/scripts/deploy_android.sh
@@ -49,7 +49,8 @@ $ADB push "$NNOPT_BUILD_DIR/$BINARY_NAME" $REMOTE_DIR/
 $ADB shell "chmod +x $REMOTE_DIR/$BINARY_NAME"
 
 # Push OpenCL library if available
-OPENCL_LIB="$HOME/.nnopt/deps/opencl/lib/android-arm64-v8a/libOpenCL.so"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_LIB="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a/libOpenCL.so"
 if [ -f "$OPENCL_LIB" ]; then
     echo "Pushing OpenCL library..."
     $ADB push "$OPENCL_LIB" $REMOTE_DIR/lib/libOpenCL.so

--- a/src/models/mamba-130m/CMakeLists.txt
+++ b/src/models/mamba-130m/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ANDROID)
 endif()
 
 # CLBlast backend
-# OpenCL headers from ~/.nnopt/deps/ (downloaded by porting orchestrator)
+# OpenCL headers from $HOME/.cache/adreno-llms/opencl/include (downloaded by scripts/setup_deps.sh).
 # These are Khronos headers with an OpenCL/ symlink for macOS compatibility
 if(DEFINED OPENCL_INCLUDE_DIR)
     message(STATUS "Using OpenCL headers from: ${OPENCL_INCLUDE_DIR}")
@@ -107,11 +107,11 @@ endif()
 # Include our Khronos headers for all project code (BEFORE ensures priority over system paths)
 include_directories(BEFORE ${OPENCL_INCLUDE_DIR})
 
-# CLBlast — prefer pre-built from ~/.nnopt/deps/clblast/, fall back to FetchContent.
+# CLBlast — built from source via CMake FetchContent (no system install needed).
 # Under fp16, SKIP the pre-built artifact: it's typically built without HALF=ON
 # (Hgemm symbol absent), and a silent Sgemm fallback would defeat the whole
 # point of the fp16 build. Always FetchContent + rebuild with HALF=ON for fp16.
-set(NNOPT_CLBLAST_DIR "$ENV{HOME}/.nnopt/deps/clblast")
+set(NNOPT_CLBLAST_DIR "$ENV{NNOPT_CLBLAST_DIR}")
 set(_NNOPT_USE_PREBUILT_CLBLAST FALSE)
 if(NOT NNOPT_DTYPE STREQUAL "fp16"
    AND EXISTS "${NNOPT_CLBLAST_DIR}/lib/libclblast.a"

--- a/src/models/mamba-130m/scripts/build.sh
+++ b/src/models/mamba-130m/scripts/build.sh
@@ -101,23 +101,38 @@ echo "Target ABI: arm64-v8a"
 echo "Target API Level: 21"
 
 # ============================================
-# Check OpenCL headers (downloaded by porting orchestrator)
-# CLBlast is built from source via CMake FetchContent
+# Check OpenCL headers + libOpenCL.so link stub.
+#
+# Cache lives at $HOME/.cache/adreno-llms/ (override with $ADRENO_LLMS_CACHE).
+# If headers are missing, scripts/setup_deps.sh is invoked automatically — it
+# downloads the Khronos OpenCL headers and pulls libOpenCL.so from a connected
+# Android device. CLBlast is built from source via CMake FetchContent on first
+# configure.
 # ============================================
-DEPS_DIR="$HOME/.nnopt/deps"
-OPENCL_INC="$DEPS_DIR/opencl/include"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_INC="$ADRENO_LLMS_CACHE/opencl/include"
+OPENCL_LIB_DIR="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a"
 
 if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
-    echo "ERROR: OpenCL headers not found at $OPENCL_INC"
-    echo "The porting orchestrator should have downloaded these."
+    SETUP_SH="$(cd "$(dirname "$0")/../../../../scripts" && pwd)/setup_deps.sh"
+    if [ -x "$SETUP_SH" ]; then
+        echo "OpenCL deps not found in $ADRENO_LLMS_CACHE — running setup_deps.sh"
+        bash "$SETUP_SH"
+    else
+        echo "ERROR: OpenCL headers not found and setup_deps.sh missing at $SETUP_SH" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
+    echo "ERROR: OpenCL headers still not found at $OPENCL_INC after setup" >&2
     exit 1
 fi
 
 echo "Using OpenCL headers: $OPENCL_INC"
 echo "CLBlast will be built from source via CMake FetchContent"
 
-# Check for extracted OpenCL library (used as stub for linking)
-OPENCL_LIB_DIR="$DEPS_DIR/opencl/lib/android-arm64-v8a"
+# Check for extracted OpenCL library (used as link-time stub).
 OPENCL_LIB="$OPENCL_LIB_DIR/libOpenCL.so"
 CMAKE_OPENCL_ARG=""
 

--- a/src/models/mamba-130m/scripts/deploy_android.sh
+++ b/src/models/mamba-130m/scripts/deploy_android.sh
@@ -49,7 +49,8 @@ $ADB push "$NNOPT_BUILD_DIR/$BINARY_NAME" $REMOTE_DIR/
 $ADB shell "chmod +x $REMOTE_DIR/$BINARY_NAME"
 
 # Push OpenCL library if available
-OPENCL_LIB="$HOME/.nnopt/deps/opencl/lib/android-arm64-v8a/libOpenCL.so"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_LIB="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a/libOpenCL.so"
 if [ -f "$OPENCL_LIB" ]; then
     echo "Pushing OpenCL library..."
     $ADB push "$OPENCL_LIB" $REMOTE_DIR/lib/libOpenCL.so

--- a/src/models/mamba2-130m/CMakeLists.txt
+++ b/src/models/mamba2-130m/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ANDROID)
 endif()
 
 # CLBlast backend
-# OpenCL headers from ~/.nnopt/deps/ (downloaded by porting orchestrator)
+# OpenCL headers from $HOME/.cache/adreno-llms/opencl/include (downloaded by scripts/setup_deps.sh).
 # These are Khronos headers with an OpenCL/ symlink for macOS compatibility
 if(DEFINED OPENCL_INCLUDE_DIR)
     message(STATUS "Using OpenCL headers from: ${OPENCL_INCLUDE_DIR}")
@@ -107,11 +107,11 @@ endif()
 # Include our Khronos headers for all project code (BEFORE ensures priority over system paths)
 include_directories(BEFORE ${OPENCL_INCLUDE_DIR})
 
-# CLBlast — prefer pre-built from ~/.nnopt/deps/clblast/, fall back to FetchContent.
+# CLBlast — built from source via CMake FetchContent (no system install needed).
 # Under fp16, SKIP the pre-built artifact: it's typically built without HALF=ON
 # (Hgemm symbol absent), and a silent Sgemm fallback would defeat the whole
 # point of the fp16 build. Always FetchContent + rebuild with HALF=ON for fp16.
-set(NNOPT_CLBLAST_DIR "$ENV{HOME}/.nnopt/deps/clblast")
+set(NNOPT_CLBLAST_DIR "$ENV{NNOPT_CLBLAST_DIR}")
 set(_NNOPT_USE_PREBUILT_CLBLAST FALSE)
 if(NOT NNOPT_DTYPE STREQUAL "fp16"
    AND EXISTS "${NNOPT_CLBLAST_DIR}/lib/libclblast.a"

--- a/src/models/mamba2-130m/scripts/build.sh
+++ b/src/models/mamba2-130m/scripts/build.sh
@@ -101,23 +101,38 @@ echo "Target ABI: arm64-v8a"
 echo "Target API Level: 21"
 
 # ============================================
-# Check OpenCL headers (downloaded by porting orchestrator)
-# CLBlast is built from source via CMake FetchContent
+# Check OpenCL headers + libOpenCL.so link stub.
+#
+# Cache lives at $HOME/.cache/adreno-llms/ (override with $ADRENO_LLMS_CACHE).
+# If headers are missing, scripts/setup_deps.sh is invoked automatically — it
+# downloads the Khronos OpenCL headers and pulls libOpenCL.so from a connected
+# Android device. CLBlast is built from source via CMake FetchContent on first
+# configure.
 # ============================================
-DEPS_DIR="$HOME/.nnopt/deps"
-OPENCL_INC="$DEPS_DIR/opencl/include"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_INC="$ADRENO_LLMS_CACHE/opencl/include"
+OPENCL_LIB_DIR="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a"
 
 if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
-    echo "ERROR: OpenCL headers not found at $OPENCL_INC"
-    echo "The porting orchestrator should have downloaded these."
+    SETUP_SH="$(cd "$(dirname "$0")/../../../../scripts" && pwd)/setup_deps.sh"
+    if [ -x "$SETUP_SH" ]; then
+        echo "OpenCL deps not found in $ADRENO_LLMS_CACHE — running setup_deps.sh"
+        bash "$SETUP_SH"
+    else
+        echo "ERROR: OpenCL headers not found and setup_deps.sh missing at $SETUP_SH" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
+    echo "ERROR: OpenCL headers still not found at $OPENCL_INC after setup" >&2
     exit 1
 fi
 
 echo "Using OpenCL headers: $OPENCL_INC"
 echo "CLBlast will be built from source via CMake FetchContent"
 
-# Check for extracted OpenCL library (used as stub for linking)
-OPENCL_LIB_DIR="$DEPS_DIR/opencl/lib/android-arm64-v8a"
+# Check for extracted OpenCL library (used as link-time stub).
 OPENCL_LIB="$OPENCL_LIB_DIR/libOpenCL.so"
 CMAKE_OPENCL_ARG=""
 

--- a/src/models/mamba2-130m/scripts/deploy_android.sh
+++ b/src/models/mamba2-130m/scripts/deploy_android.sh
@@ -49,7 +49,8 @@ $ADB push "$NNOPT_BUILD_DIR/$BINARY_NAME" $REMOTE_DIR/
 $ADB shell "chmod +x $REMOTE_DIR/$BINARY_NAME"
 
 # Push OpenCL library if available
-OPENCL_LIB="$HOME/.nnopt/deps/opencl/lib/android-arm64-v8a/libOpenCL.so"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_LIB="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a/libOpenCL.so"
 if [ -f "$OPENCL_LIB" ]; then
     echo "Pushing OpenCL library..."
     $ADB push "$OPENCL_LIB" $REMOTE_DIR/lib/libOpenCL.so

--- a/src/models/openelm-270m/CMakeLists.txt
+++ b/src/models/openelm-270m/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ANDROID)
 endif()
 
 # CLBlast backend
-# OpenCL headers from ~/.nnopt/deps/ (downloaded by porting orchestrator)
+# OpenCL headers from $HOME/.cache/adreno-llms/opencl/include (downloaded by scripts/setup_deps.sh).
 # These are Khronos headers with an OpenCL/ symlink for macOS compatibility
 if(DEFINED OPENCL_INCLUDE_DIR)
     message(STATUS "Using OpenCL headers from: ${OPENCL_INCLUDE_DIR}")
@@ -107,11 +107,11 @@ endif()
 # Include our Khronos headers for all project code (BEFORE ensures priority over system paths)
 include_directories(BEFORE ${OPENCL_INCLUDE_DIR})
 
-# CLBlast — prefer pre-built from ~/.nnopt/deps/clblast/, fall back to FetchContent.
+# CLBlast — built from source via CMake FetchContent (no system install needed).
 # Under fp16, SKIP the pre-built artifact: it's typically built without HALF=ON
 # (Hgemm symbol absent), and a silent Sgemm fallback would defeat the whole
 # point of the fp16 build. Always FetchContent + rebuild with HALF=ON for fp16.
-set(NNOPT_CLBLAST_DIR "$ENV{HOME}/.nnopt/deps/clblast")
+set(NNOPT_CLBLAST_DIR "$ENV{NNOPT_CLBLAST_DIR}")
 set(_NNOPT_USE_PREBUILT_CLBLAST FALSE)
 if(NOT NNOPT_DTYPE STREQUAL "fp16"
    AND EXISTS "${NNOPT_CLBLAST_DIR}/lib/libclblast.a"

--- a/src/models/openelm-270m/scripts/build.sh
+++ b/src/models/openelm-270m/scripts/build.sh
@@ -101,23 +101,38 @@ echo "Target ABI: arm64-v8a"
 echo "Target API Level: 21"
 
 # ============================================
-# Check OpenCL headers (downloaded by porting orchestrator)
-# CLBlast is built from source via CMake FetchContent
+# Check OpenCL headers + libOpenCL.so link stub.
+#
+# Cache lives at $HOME/.cache/adreno-llms/ (override with $ADRENO_LLMS_CACHE).
+# If headers are missing, scripts/setup_deps.sh is invoked automatically — it
+# downloads the Khronos OpenCL headers and pulls libOpenCL.so from a connected
+# Android device. CLBlast is built from source via CMake FetchContent on first
+# configure.
 # ============================================
-DEPS_DIR="$HOME/.nnopt/deps"
-OPENCL_INC="$DEPS_DIR/opencl/include"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_INC="$ADRENO_LLMS_CACHE/opencl/include"
+OPENCL_LIB_DIR="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a"
 
 if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
-    echo "ERROR: OpenCL headers not found at $OPENCL_INC"
-    echo "The porting orchestrator should have downloaded these."
+    SETUP_SH="$(cd "$(dirname "$0")/../../../../scripts" && pwd)/setup_deps.sh"
+    if [ -x "$SETUP_SH" ]; then
+        echo "OpenCL deps not found in $ADRENO_LLMS_CACHE — running setup_deps.sh"
+        bash "$SETUP_SH"
+    else
+        echo "ERROR: OpenCL headers not found and setup_deps.sh missing at $SETUP_SH" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
+    echo "ERROR: OpenCL headers still not found at $OPENCL_INC after setup" >&2
     exit 1
 fi
 
 echo "Using OpenCL headers: $OPENCL_INC"
 echo "CLBlast will be built from source via CMake FetchContent"
 
-# Check for extracted OpenCL library (used as stub for linking)
-OPENCL_LIB_DIR="$DEPS_DIR/opencl/lib/android-arm64-v8a"
+# Check for extracted OpenCL library (used as link-time stub).
 OPENCL_LIB="$OPENCL_LIB_DIR/libOpenCL.so"
 CMAKE_OPENCL_ARG=""
 

--- a/src/models/openelm-270m/scripts/deploy_android.sh
+++ b/src/models/openelm-270m/scripts/deploy_android.sh
@@ -49,7 +49,8 @@ $ADB push "$NNOPT_BUILD_DIR/$BINARY_NAME" $REMOTE_DIR/
 $ADB shell "chmod +x $REMOTE_DIR/$BINARY_NAME"
 
 # Push OpenCL library if available
-OPENCL_LIB="$HOME/.nnopt/deps/opencl/lib/android-arm64-v8a/libOpenCL.so"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_LIB="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a/libOpenCL.so"
 if [ -f "$OPENCL_LIB" ]; then
     echo "Pushing OpenCL library..."
     $ADB push "$OPENCL_LIB" $REMOTE_DIR/lib/libOpenCL.so

--- a/src/models/qwen2-5-0-5b/CMakeLists.txt
+++ b/src/models/qwen2-5-0-5b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ANDROID)
 endif()
 
 # CLBlast backend
-# OpenCL headers from ~/.nnopt/deps/ (downloaded by porting orchestrator)
+# OpenCL headers from $HOME/.cache/adreno-llms/opencl/include (downloaded by scripts/setup_deps.sh).
 # These are Khronos headers with an OpenCL/ symlink for macOS compatibility
 if(DEFINED OPENCL_INCLUDE_DIR)
     message(STATUS "Using OpenCL headers from: ${OPENCL_INCLUDE_DIR}")
@@ -107,11 +107,11 @@ endif()
 # Include our Khronos headers for all project code (BEFORE ensures priority over system paths)
 include_directories(BEFORE ${OPENCL_INCLUDE_DIR})
 
-# CLBlast — prefer pre-built from ~/.nnopt/deps/clblast/, fall back to FetchContent.
+# CLBlast — built from source via CMake FetchContent (no system install needed).
 # Under fp16, SKIP the pre-built artifact: it's typically built without HALF=ON
 # (Hgemm symbol absent), and a silent Sgemm fallback would defeat the whole
 # point of the fp16 build. Always FetchContent + rebuild with HALF=ON for fp16.
-set(NNOPT_CLBLAST_DIR "$ENV{HOME}/.nnopt/deps/clblast")
+set(NNOPT_CLBLAST_DIR "$ENV{NNOPT_CLBLAST_DIR}")
 set(_NNOPT_USE_PREBUILT_CLBLAST FALSE)
 if(NOT NNOPT_DTYPE STREQUAL "fp16"
    AND EXISTS "${NNOPT_CLBLAST_DIR}/lib/libclblast.a"

--- a/src/models/qwen2-5-0-5b/scripts/build.sh
+++ b/src/models/qwen2-5-0-5b/scripts/build.sh
@@ -101,23 +101,38 @@ echo "Target ABI: arm64-v8a"
 echo "Target API Level: 21"
 
 # ============================================
-# Check OpenCL headers (downloaded by porting orchestrator)
-# CLBlast is built from source via CMake FetchContent
+# Check OpenCL headers + libOpenCL.so link stub.
+#
+# Cache lives at $HOME/.cache/adreno-llms/ (override with $ADRENO_LLMS_CACHE).
+# If headers are missing, scripts/setup_deps.sh is invoked automatically — it
+# downloads the Khronos OpenCL headers and pulls libOpenCL.so from a connected
+# Android device. CLBlast is built from source via CMake FetchContent on first
+# configure.
 # ============================================
-DEPS_DIR="$HOME/.nnopt/deps"
-OPENCL_INC="$DEPS_DIR/opencl/include"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_INC="$ADRENO_LLMS_CACHE/opencl/include"
+OPENCL_LIB_DIR="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a"
 
 if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
-    echo "ERROR: OpenCL headers not found at $OPENCL_INC"
-    echo "The porting orchestrator should have downloaded these."
+    SETUP_SH="$(cd "$(dirname "$0")/../../../../scripts" && pwd)/setup_deps.sh"
+    if [ -x "$SETUP_SH" ]; then
+        echo "OpenCL deps not found in $ADRENO_LLMS_CACHE — running setup_deps.sh"
+        bash "$SETUP_SH"
+    else
+        echo "ERROR: OpenCL headers not found and setup_deps.sh missing at $SETUP_SH" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
+    echo "ERROR: OpenCL headers still not found at $OPENCL_INC after setup" >&2
     exit 1
 fi
 
 echo "Using OpenCL headers: $OPENCL_INC"
 echo "CLBlast will be built from source via CMake FetchContent"
 
-# Check for extracted OpenCL library (used as stub for linking)
-OPENCL_LIB_DIR="$DEPS_DIR/opencl/lib/android-arm64-v8a"
+# Check for extracted OpenCL library (used as link-time stub).
 OPENCL_LIB="$OPENCL_LIB_DIR/libOpenCL.so"
 CMAKE_OPENCL_ARG=""
 

--- a/src/models/qwen2-5-0-5b/scripts/deploy_android.sh
+++ b/src/models/qwen2-5-0-5b/scripts/deploy_android.sh
@@ -49,7 +49,8 @@ $ADB push "$NNOPT_BUILD_DIR/$BINARY_NAME" $REMOTE_DIR/
 $ADB shell "chmod +x $REMOTE_DIR/$BINARY_NAME"
 
 # Push OpenCL library if available
-OPENCL_LIB="$HOME/.nnopt/deps/opencl/lib/android-arm64-v8a/libOpenCL.so"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_LIB="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a/libOpenCL.so"
 if [ -f "$OPENCL_LIB" ]; then
     echo "Pushing OpenCL library..."
     $ADB push "$OPENCL_LIB" $REMOTE_DIR/lib/libOpenCL.so

--- a/src/models/smollm2-135m-instruct/scripts/build.sh
+++ b/src/models/smollm2-135m-instruct/scripts/build.sh
@@ -101,23 +101,38 @@ echo "Target ABI: arm64-v8a"
 echo "Target API Level: 21"
 
 # ============================================
-# Check OpenCL headers (downloaded by porting orchestrator)
-# CLBlast is built from source via CMake FetchContent
+# Check OpenCL headers + libOpenCL.so link stub.
+#
+# Cache lives at $HOME/.cache/adreno-llms/ (override with $ADRENO_LLMS_CACHE).
+# If headers are missing, scripts/setup_deps.sh is invoked automatically — it
+# downloads the Khronos OpenCL headers and pulls libOpenCL.so from a connected
+# Android device. CLBlast is built from source via CMake FetchContent on first
+# configure.
 # ============================================
-DEPS_DIR="$HOME/.nnopt/deps"
-OPENCL_INC="$DEPS_DIR/opencl/include"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_INC="$ADRENO_LLMS_CACHE/opencl/include"
+OPENCL_LIB_DIR="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a"
 
 if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
-    echo "ERROR: OpenCL headers not found at $OPENCL_INC"
-    echo "The porting orchestrator should have downloaded these."
+    SETUP_SH="$(cd "$(dirname "$0")/../../../../scripts" && pwd)/setup_deps.sh"
+    if [ -x "$SETUP_SH" ]; then
+        echo "OpenCL deps not found in $ADRENO_LLMS_CACHE — running setup_deps.sh"
+        bash "$SETUP_SH"
+    else
+        echo "ERROR: OpenCL headers not found and setup_deps.sh missing at $SETUP_SH" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f "$OPENCL_INC/CL/cl.h" ]; then
+    echo "ERROR: OpenCL headers still not found at $OPENCL_INC after setup" >&2
     exit 1
 fi
 
 echo "Using OpenCL headers: $OPENCL_INC"
 echo "CLBlast will be built from source via CMake FetchContent"
 
-# Check for extracted OpenCL library (used as stub for linking)
-OPENCL_LIB_DIR="$DEPS_DIR/opencl/lib/android-arm64-v8a"
+# Check for extracted OpenCL library (used as link-time stub).
 OPENCL_LIB="$OPENCL_LIB_DIR/libOpenCL.so"
 CMAKE_OPENCL_ARG=""
 

--- a/src/models/smollm2-135m-instruct/scripts/deploy_android.sh
+++ b/src/models/smollm2-135m-instruct/scripts/deploy_android.sh
@@ -53,7 +53,8 @@ $ADB shell "chmod +x $REMOTE_DIR/$BINARY_NAME"
 # requested (Deploy(full_deploy=true) uses this script).
 
 # Push OpenCL library if available
-OPENCL_LIB="$HOME/.nnopt/deps/opencl/lib/android-arm64-v8a/libOpenCL.so"
+ADRENO_LLMS_CACHE="${ADRENO_LLMS_CACHE:-$HOME/.cache/adreno-llms}"
+OPENCL_LIB="$ADRENO_LLMS_CACHE/opencl/lib/android-arm64-v8a/libOpenCL.so"
 if [ -f "$OPENCL_LIB" ]; then
     echo "Pushing OpenCL library..."
     $ADB push "$OPENCL_LIB" $REMOTE_DIR/lib/libOpenCL.so


### PR DESCRIPTION
…/adreno-llms/ and auto-invoke setup_deps.sh if the headers/lib are missing