### PR TITLE
OpenELM-270M decode rewrite (2.3x) + shared device-info upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ State-of-the-art small language models running on **Adreno 6xx GPUs** — the GP
 
 Each model ships with **hand-written OpenCL kernels tuned for Adreno's WG=64 wave size, vec4 fp16 ALUs, and image-cache texture path:**
 
-- **`gemv_m1.cl`** — cooperative-WG=64 GEMV with vec4 fp16 + fp32 accumulator + `__local`-mem tree reduce. The decode-path workhorse, replacing CLBlast HGemm at every M=1 site (q/k/v/o-proj, gate/up/down-proj, lm_head). A `_no8` multi-output variant produces 4 output columns per WG when N is divisible by 4.
-- **`block_fused.cl`** — fused-residual GEMV variants that write `out[i] = sum + residual[i]` in a single launch (kills the separate `element_add` kernel after attn out-proj and MLP down-proj).
+- **`gemv_m1.cl`** — cooperative-WG=64 GEMV with vec4 fp16 + fp32 accumulator + `__local`-mem tree reduce. The decode-path workhorse, replacing CLBlast HGemm at every M=1 site (q/k/v/o-proj, gate/up/down-proj, lm_head). Hand-unrolled K-specialized variants (`_k768`, `_k1280`, `_k1536`) plus a generic-K **`_no4_coalesced`** path (vec4-strided across the warp for coalesced 256-byte DRAM reads) that hits 9–12 GB/s on Adreno 618. Adding the K=1280 specialization + coalesced generic to OpenELM-270M was the single largest unlock — **2.3× decode-throughput jump (4.60 → 10.59 tok/s)** before any other host-side work landed.
+- **`block_fused.cl`** — fused-residual GEMV variants (`gemv_m1_no4_radd`, `gemv_m1_k1280_no4_radd`, `gemv_m1_no4_radd_coalesced`) that write `hidden[i] += sum` in a single launch, killing the separate `element_add` kernel after attn out-proj and MLP down-proj.
 - **`attention.cl`** — grouped-query attention scores + softmax + out-proj.
 - **`mlp.cl` / `mlp_swiglu.cl`** — fused gate × silu × up.
 - **`rope.cl`** — rotary position embedding.
@@ -26,18 +26,25 @@ Each model ships with **hand-written OpenCL kernels tuned for Adreno's WG=64 wav
 
 CLBlast 1.6.3 handles the M>1 prefill GEMMs; the custom `gemv_m1` path takes over for M=1 decode.
 
+Decode-loop techniques that compound on top of the kernels:
+
+- **Chained cl_mem decode + ping-pong async readback** (OpenELM-270M, mamba2): the next iteration's embedding reads its token id directly from the previous iteration's GPU-side `argmax_result_` buffer (no host roundtrip). Async `clEnqueueReadBuffer(CL_FALSE)` of the int32 token is overlapped with the next forward's enqueue via a two-slot ping-pong. Closed a 33% wall-vs-GPU gap, **+1.38× on OpenELM (10.59 → 14.62 tok/s)**.
+- **Persistent activation buffers** for every per-layer scratch: qkv, q/k norm output, attention scores, ctx, projection output, MLP gate, MLP outputs — plus the residual-stream embedding output, RMSNorm outputs, and lm_head logits at the model level. Eliminates per-decode-token `clCreateBuffer`/`clReleaseMemObject` round-trips entirely on the hot path.
+- **GPU-side argmax** (`argmax.cl`): single-WG cooperative tree-reduction over the vocab, returning a 4-byte int32 instead of a 50K–150K-element fp16 readback + host scan.
+- **Pre-built RoPE tables sized to MAX_CONTEXT_LENGTH at init** — eliminates the per-decode-step host-side trig recompute + buffer regrowth.
+
 ## 📊 Models
 
-Decode tok/s = 5-run warm median, fp16, greedy, 32-token generation, measured 2026-05-06.
+Decode tok/s = 5-run warm median (OpenELM-270M is 10-run), fp16, greedy, 32-token generation, measured 2026-05-07.
 
 | Model | Params | Architecture | Device | Decode tok/s | TTFT (s) | Notes |
 |---|---:|---|---|---:|---:|---|
 | [Mamba2-130M](src/models/mamba2-130m/) | 130M | SSD | Razr 2020 (Adreno 618) | 23.18 | 1.53 | State-space duality |
 | [Mamba-130M](src/models/mamba-130m/) | 130M | SSM | Razr 2020 (Adreno 618) | 22.15 | 1.60 | No attention |
 | [SmolLM2-135M-Instruct](src/models/smollm2-135m-instruct/) | 135M | LLaMA + GQA | Razr 2020 (Adreno 618) | 23.65 | 1.53 | Instruct-tuned; 61% of ceiling |
+| [OpenELM-270M](src/models/openelm-270m/) | 270M | LLaMA-style + tied lm_head | Razr 2020 (Adreno 618) | **14.81** (32 tok) / **15.22** (40 tok) | 1.93 | **3.31× over prior 4.47**; 78.9% of 10 GB/s ceiling at 40-token median |
 | [LFM2.5-350M-Base](src/models/lfm2-5-350m/) | 350M | Hybrid conv+attn | Razr 2020 (Adreno 618) | 10.20 | 3.72 | Liquid AI hybrid |
-| [Qwen2.5-0.5B](src/models/qwen2-5-0-5b/) | 500M | LLaMA + GQA | Razr 2020 (Adreno 618) | 8.45 | 2.59 | Largest in the repo; ~80% of memory ceiling |
-| [OpenELM-270M](src/models/openelm-270m/) | 270M | LLaMA-style | Razr 2020 (Adreno 618) | 4.47 | 2.13 | Apple weights — fetch script only |
+| [Qwen2.5-0.5B](src/models/qwen2-5-0-5b/) | 500M | LLaMA + GQA | Razr 2020 (Adreno 618) | **10.41** | 2.59 | Largest in the repo; chained cl_mem decode + fused QKV → 70% of 14 GB/s ceiling |
 
 ## 🚀 Quickstart
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Decode tok/s = 5-run warm median (OpenELM-270M is 10-run), fp16, greedy, 32-toke
 | [Mamba-130M](src/models/mamba-130m/) | 130M | SSM | Razr 2020 (Adreno 618) | 22.15 | 1.60 | No attention |
 | [SmolLM2-135M-Instruct](src/models/smollm2-135m-instruct/) | 135M | LLaMA + GQA | Razr 2020 (Adreno 618) | 23.65 | 1.53 | Instruct-tuned; 61% of ceiling |
 | [OpenELM-270M](src/models/openelm-270m/) | 270M | LLaMA-style + tied lm_head | Razr 2020 (Adreno 618) | **14.81** (32 tok) / **15.22** (40 tok) | 1.93 | **3.31× over prior 4.47**; 78.9% of 10 GB/s ceiling at 40-token median |
-| [LFM2.5-350M-Base](src/models/lfm2-5-350m/) | 350M | Hybrid conv+attn | Razr 2020 (Adreno 618) | 10.20 | 3.72 | Liquid AI hybrid |
+| [LFM2.5-350M-Base](src/models/lfm2-5-350m/) | 350M | Hybrid conv+attn | Razr 2020 (Adreno 620) | **11.51** | 3.73 | Liquid AI hybrid; 58% of texture ceiling, conv-block fused decode + `__constant` x in no8_img GEMV |
 | [Qwen2.5-0.5B](src/models/qwen2-5-0-5b/) | 500M | LLaMA + GQA | Razr 2020 (Adreno 618) | **10.41** | 2.59 | Largest in the repo; chained cl_mem decode + fused QKV → 70% of 14 GB/s ceiling |
 
 ## 🚀 Quickstart

--- a/src/models/lfm2-5-350m/BENCHMARK.md
+++ b/src/models/lfm2-5-350m/BENCHMARK.md
@@ -497,6 +497,134 @@ Dispatcher in `src/utils.cpp::run_gemv_m1_image` selects no8 when `K==1024 && N>
 | % of 13.46 GB/s texture ceiling | 51% | **56%** | +5 pp |
 | Tokens deterministic | ✓ | ✓ | ID-for-ID matched |
 
+## ── Session 4 (2026-05-07) — Adreno-guide-driven cleanup + lever #4 ──
+
+After reading the Snapdragon OpenCL Programming Guide (80-NB295-11 Rev. C) end-to-end, surveyed five untried levers (recordable_queues, subgroup_shuffle reduce, onchip_global_memory, max_constant_size on x, full-wave WG=128 + shuffle reduce). Profiled the post-Step-11 hot path then attacked the bottleneck.
+
+### Step 13 — `cl_qcom_recordable_queues` proven, but not integrated
+
+Ported the recordable-queues probe to lfm2 (`run_record_probe()` in main.cpp + `probe_noop` kernel in gemv_m1.cl). Triggered by `NNOPT_RECORD_PROBE=1`. **Recipe that works on Adreno 620 (driver E031.37.12.07):** create queue with `clCreateCommandQueue(ctx, dev, CL_QUEUE_RECORDABLE_QCOM /*0x40000000*/ alone, &err)` — NOT combined with `CL_QUEUE_PROFILING_ENABLE`. The earlier (qwen2.5) investigation comment claiming "no candidate worked" was stale — bit-30-alone DOES work.
+
+```
+Record: WIN attempt 400 (probe_q=0xb40000789a490f30)
+Baseline: 10000 sequential dispatches → 186.92 ms (18.69 µs/dispatch)
+Replay:   10000 dispatches            →  85.70 ms ( 8.57 µs/dispatch)
+Record: speedup = 2.18×
+```
+
+Did NOT integrate into `Model::generate()` after analysis showed expected wall-clock gain ≈ 0.5–2 ms/token. Reason: prior BENCHMARK Step 10 + Step 12 evidence already established that on this device's in-order queue, host CPU is overlapped with GPU; saving CPU dispatch time doesn't shorten the wall. Confirmed independently in this session (Step 14 + Step 15 below). Probe + plumbing kept in tree for future int8/onchip_global_memory work that needs a recording context.
+
+### Step 14 — Recordable-ready cleanup of chained-decode forward (PHASE 2A)
+
+Eliminated all 4 non-NDRange enqueues from `forward_greedy_chained_enqueue` (only `clEnqueueNDRangeKernel` is recordable per guide §9.1.3). Specifically:
+- `embedding.cpp:109` — bound `token_ids_dev` directly as kernel arg 0 when `dev_offset_bytes==0`, eliminating the per-token `clEnqueueCopyBuffer(token_ids_dev → buf_input_ids_)`.
+- `attention.cpp:374` — q/k_layernorm `clEnqueueCopyBuffer(tmp → buf)` removed by passing `buf` as both input AND output to `rmsnorm_forward` (in-place is safe: each work-item owns disjoint columns; the barrier between read+reduce and write phases is preserved).
+- `attention.cpp:429,431` — KV cache writes converted from `clEnqueueCopyBuffer` to a new `kv_write` NDRange kernel in `kernels/attention.cl` (one work-item per element of the row, reads `start_pos` as a scalar arg). Prefill (`seq_q>1`) keeps `clEnqueueCopyBuffer` because one big copy beats `seq_q` per-row launches there.
+
+| Run | decode tok/s | tokens deterministic |
+|---|---|---|
+| 1 | 11.1841 | ✓ exact |
+| 2 | 11.0085 | ✓ exact |
+| 3 | 11.3356 | ✓ exact |
+| **median** | **11.1841** | ✓ |
+
+**Step 14 / Step 11:** 0.998× — neutral. Expected: refactoring API calls without changing kernel work. Value is unlocking recording-readiness for future levers.
+
+### Step 15 — Conv block fusion for decode (PHASE 2B-pivot)
+
+Profile showed conv layers fired 9 dispatches each (`copy_transpose / split_chunk3 / pointwise_mul / conv1d_causal_with_cache / copy_transpose_back_state / update_state / mul_C / copy_transpose_back` + the bracketing GEMVs), totaling ~22 ms GPU / 32 tokens. For decode (seq_q=1) the four transposes are no-ops (single-token tensors don't reshape) and the rest are per-channel work on H=1024 elements.
+
+Added `conv_block_decode` kernel in `kernels/convolution.cl` — one work-item per channel does B/C/X read + Bx + conv1d (with state read+update) + multiply by C, all in one launch. Math is bit-identical to the unfused path (verified: tokens match ID-for-ID across all 5 runs against the locked reference).
+
+Profile delta for the conv layer:
+
+| Site | Pre-Step-15 | Post-Step-15 | Notes |
+|---|---|---|---|
+| 7 conv helper kernels combined | ~22 ms / 32 tokens | n/a (skipped at decode) | seq_q=1 skips them |
+| `conv_block_decode` (new) | n/a | 9.85 ms / 32 tokens | 31.8 µs/call vs ~71 µs unfused sum |
+
+| Run | decode tok/s | tokens deterministic |
+|---|---|---|
+| 1 | 11.2564 | ✓ |
+| 2 | 10.8978 | ✓ |
+| 3 | 11.2305 | ✓ |
+| 4 | 11.3384 | ✓ |
+| 5 | 11.2381 | ✓ |
+| **median** | **11.2381** | ✓ |
+
+**Step 15 / Step 11:** 1.002× — wall-neutral but GPU active time reduced by ~0.4 ms/tok. Confirms (third time independently this port) that on Adreno 620 with the in-order command queue, dispatch-count cuts and CPU savings don't propagate to wall-clock — the queue's natural pipelining already hides them. **Kept anyway** because: (a) the conv path is structurally cleaner, (b) less L2 traffic between intermediate buffers, (c) lower power consumption, (d) prerequisite for any future block-level recording-queue capture.
+
+### Step 16 — `sub_group_reduce_add` in image GEMVs ❌ NOT shipped
+
+Tried replacing the `__local`-mem tree reduce in the four image GEMV kernels (no2_img, no4_img K=1024, no8_img K=1024, no4_img K=4608) with `sub_group_reduce_add` per Snapdragon Programming Guide §9.2.2 ("Adreno has hardware support for the reduction functions, much faster than doing reduction through local memory").
+
+**Two regressions hit:**
+
+1. **Without `qcom_reqd_sub_group_size("full")`:** tokens diverged at the very first generated token ("The teacher worked at the **0**" instead of "**3rd**"). Cause: Adreno 620 default subgroup_size = 32 (half-wave); `sub_group_reduce_add` only sums 32 of 64 lanes, halving the GEMV output. Decode dropped to 5.07 tok/s.
+
+2. **With `qcom_reqd_sub_group_size("full")`:** tokens correct ✓ but decode collapsed to 1.51 tok/s (**7.4× slower** than baseline). Cause: forcing full-wave on the no8_img kernel (~50 fp32-equivalent regs/thread for 8 acc + 9 fp16x4 in flight) either spilled registers or halved active lanes when the actual full wave width was 128 — exactly the failure mode the BENCHMARK Lever A/B section warned about.
+
+Reverted everything (kernel bodies + `-cl-std=CL2.0` build flag). The existing tree-reduce stays — at WG=64 == one wave (or even half-wave), the inter-iteration barriers compile to ~no-ops on Adreno, and the tree-reduce is essentially free.
+
+**Lesson recorded for later:** wave-shuffle reduce on Adreno 620 image GEMVs requires either (a) a two-level reduce that's subgroup-size-agnostic (sub_group_reduce_add for the inner subgroup + __local for cross-subgroup combine), or (b) confirmation the kernel's compiler-picked wave size matches WG, then no attribute needed. Not worth the complexity given the alternatives below.
+
+### Step 17 — `__constant` x with `max_constant_size` in `gemv_m1_k1024_no8_img` ✅ landed
+
+Adreno guide §6.4 / §7.1.3: an array passed as `__constant` with the `max_constant_size(N)` attribute is promoted to on-chip constant memory, which "can broadcast into ALUs in no time for fast ALU computing. All other memories (global, local, and private) must go through the lengthy load/store path."
+
+`x` in the GEMV is exactly the right pattern: 1024 fp16 = 2048 B (well under the constant-cache budget), read N times per kernel (4608 times in the K=1024 N=4608 site), with all 64 lanes reading the same `x[off..off+3]` vec4 at each K-iteration — the canonical "uniform broadcast" the constant cache is built for.
+
+Applied to `gemv_m1_k1024_no8_img` only:
+```c
+void gemv_m1_k1024_no8_img(
+    __constant storage_t* x __attribute__((max_constant_size(2048))),
+    __read_only image2d_t W_img,
+    __global storage_t* out, const int N) { ... }
+```
+Body unchanged except `__global const half* xh` → `__constant const half* xh`.
+
+| Run | decode tok/s | tokens deterministic |
+|---|---|---|
+| 1 | 11.4677 | ✓ exact |
+| 2 | 11.4435 | ✓ exact |
+| 3 | 11.5457 | ✓ exact |
+| 4 | 11.5109 | ✓ exact |
+| 5 | 11.5132 | ✓ exact |
+| **median** | **11.5109** | ✓ |
+
+**Step 17 / Step 11 (session-3 final):** **1.026× = +2.6%.** Per-token decode time: 1000 / 11.51 = **86.9 ms/token** (down from 89.2). Effective decode BW: 676 MB / 86.9 ms = **7.78 GB/s = 58% of 13.46 GB/s texture ceiling** (up from 56%).
+
+**Tried also applying `__constant` to the other three image GEMV kernels** (no4_img K=1024, no2_img K=1024, no4_img K=4608 with max_constant_size 9216 for the K=4608 case). Result: catastrophic regression to ~5.16 tok/s. Cause: when multiple kernels in the same `cl_program` declare `__constant` args with sizable `max_constant_size`, the per-program constant cache budget is split / exceeded on Adreno 620, falling back some kernels to off-chip system memory. Reverted to keep `__constant` on `no8_img` only — the kernel where `x` is reused 32× per launch (8 outputs × 4 K-iterations) so the broadcast saving compounds most.
+
+## Session 4 final state
+
+| Metric | Step 11 (session-3 final) | Step 17 (session-4 final) | Δ |
+|---|---|---|---|
+| Decode tok/s | 11.21 | **11.51** | **+2.6%** |
+| Decode ms/token | 89.2 | 86.9 | −2.3 ms |
+| Effective decode BW | 7.58 GB/s | 7.78 GB/s | +0.20 GB/s |
+| % of 13.46 GB/s texture ceiling | 56% | **58%** | +2 pp |
+| Tokens deterministic | ✓ | ✓ | ID-for-ID matched |
+| Recording-ready forward | ✗ | ✓ | clEnqueueCopyBuffer eliminated |
+
+**Cumulative Session 1 → 4:** 4.5486 → **11.5109** = **2.53×** improvement on decode tok/s, 22% → 58% of texture ceiling.
+
+**What's left unmoved (after this session's profiling):**
+- Wall is GEMV-bound. Further fp16 wins can only come from compressing per-call inner loop further (no12_img / no16_img, two-level subgroup-shuffle reduce, image2d with smaller pix-stride). All hit the same VGPR / occupancy wall the BENCHMARK already documents.
+- `cl_qcom_recordable_queues` infra is in tree (`run_record_probe` + `probe_noop` kernel) but not integrated into `Model::generate` because the gain analysis came in below the engineering cost.
+- `cl_qcom_onchip_global_memory` (lever #3) untried — would need recordable_queues integration first to preserve activations across recorded kernels.
+- 15 tok/s remains structurally out of reach on fp16 (676 MB/tok ÷ 13.46 GB/s = 50.2 ms/tok = 19.9 tok/s absolute max). Honest path stays int8 weight quantization.
+
+## Repo state — session 4
+
+- `kernels/gemv_m1.cl` — added `probe_noop` (recordable-queues test kernel); `gemv_m1_k1024_no8_img` now takes `x` as `__constant` with `max_constant_size(2048)`. Other image kernels stay `__global` (per-program constant budget).
+- `kernels/attention.cl` — added `kv_write` NDRange kernel; replaces `clEnqueueCopyBuffer` for KV-cache append in decode (`seq_q==1`).
+- `kernels/convolution.cl` — added `conv_block_decode` fused per-channel kernel for decode; replaces 7 helper kernels at `seq_q==1`.
+- `src/main.cpp` — added `<dlfcn.h>` + `<CL/cl.h>` includes, `run_record_probe()` (≈170 lines), `NNOPT_RECORD_PROBE=1` env-var dispatch.
+- `src/layers/embedding.cpp` — chained `forward_from_device_token` binds `token_ids_dev` directly as kernel arg 0 when `dev_offset_bytes==0`, skipping the per-token `clEnqueueCopyBuffer`.
+- `src/layers/attention.{h,cpp}` — added `kv_write_kernel_` member; `apply_qk_norm` lambda now writes in-place (`buf` as both x and out to rmsnorm); KV cache append uses `kv_write_kernel_` for `seq_q==1`.
+- `src/layers/convolution.{h,cpp}` — added `block_decode_kernel_` member; `forward()` takes the fused fast path when `seq_len==1 && state_len>0`.
+
 **Path to 15 tok/s — what's needed:**
 - 15 tok/s = 66.7 ms/token wall = 75% of texture ceiling. Need to save another 22.5 ms/token from the current 89.2.
 - Per-shape utilization at Step 11 close: K=1024 sites at 65–70% (no8_img), K=4608 site at 85% (no4_img is already optimal). If K=1024 could match K=4608's 85%, savings would be ~10 ms/token → 13 tok/s. **Still short of 15.**

--- a/src/models/lfm2-5-350m/BENCHMARK.md
+++ b/src/models/lfm2-5-350m/BENCHMARK.md
@@ -393,6 +393,130 @@ What's left on the table:
 - **Persistent activation buffers** (eliminate per-call `clCreateBuffer` inside `Attention::forward` / `Convolution::forward` / `Mlp::forward`): predicted 1.01–1.02× since GPU-active is already 90% of wall.
 - **int8 quantization**: project rule defers; would 2× the BW budget instantly (676 MB → 338 MB → 14.8 → 29.6 tok/s ceiling).
 
+## ── Session 3 (2026-05-07) — past Step 7, push toward 15 tok/s ──
+
+User goal: 15 tok/s. After Step 7 we sit at 51% of the 19.9 tok/s texture roofline; 15 tok/s = 75%. Plan attacks the two biggest remaining levers identified in the post-Step-7 profile: host-side blocking readback (Step 10) and K=1024 GEMV underutilization at 60% of texture ceiling vs K=4608 at 85% (Step 11).
+
+## Step 9 — post-Step-7 baseline profile (informational)
+
+Profile run with `NNOPT_PROFILE=1 NNOPT_KERNEL_PROFILE=1`. Wall = 95.9 ms/token (10.42 tok/s in profile). Total GPU kernel time = 83.6 ms/token. Host gap = 12.3 ms/token (down from baseline's 21 ms; the chained-decode work in Step 10 targets this 12 ms).
+
+Per-call BW utilization (vs 13.46 GB/s texture ceiling):
+- K=1024 N=4608: 1167 µs/call → 8.1 GB/s = **60%**
+- K=1024 N=65536 (per tile): 4078 µs → 7.85 GB/s = **58%**
+- K=4608 N=1024 (no4): 822 µs → 11.4 GB/s = **85%** ← ceiling
+- K=1024 N=3072: 789 µs → 8.0 GB/s = **59%**
+- K=1024 N=1024: 284 µs → 7.4 GB/s = **55%**
+- K=1024 N=512: 157 µs → 6.7 GB/s = **50%**
+
+**Key signal:** K=4608 hits 85% with the same no4 kernel design that K=1024 stalls at 60% on. The difference is per-thread iteration count: K=4608 no4 = 18 K-iter × 4 outputs = 72 dot products per thread; K=1024 no4 = 4 K-iter × 4 outputs = 16. K=1024 has too few in-flight reads to saturate the texture engine. Step 11 attacks this.
+
+## Step 10 — chained decode + async readback (3-run median, neutral)
+
+**Lever.** Eliminate the blocking `clEnqueueReadBuffer(argmax_out_idx_, CL_TRUE, ...)` at the end of `Model::forward_greedy()` (model.cpp:354). Add a new `forward_greedy_chained_enqueue(start_pos)` that mirrors `forward_greedy` but (a) the embedding reads its single token id from the *previous* iteration's argmax output via `clEnqueueCopyBuffer(argmax_out_idx_ → buf_input_ids_, 4 bytes)` instead of from a host-supplied vector, (b) skips the per-call `clCreateSubBuffer` for the argmax row (offset=0 at seq_len=1 means logits_buf_ itself is the row), and (c) does NOT block on a host readback. `Model::generate()` runs a ping-pong loop: enqueue forward N+1, enqueue *non-blocking* readback for slot (N+1)&1, `clFlush`, then `clWaitForEvents` on slot N&1's readback to consume the int32 from the previous iteration. The host stays one step ahead in enqueue and one step behind in readback, hiding the readback latency behind the next forward's enqueue. Reference: openelm-270m's Step 9 pattern.
+
+| Run | decode tok/s | tokens deterministic |
+|---|---|---|
+| 1 | 9.91 | ✓ |
+| 2 | 9.67 | ✓ |
+| 3 | 10.24 | ✓ |
+| **median** | **9.94** | ✓ |
+
+**Step 10 / Step 7:** **0.974×** — within run-to-run variance, effectively neutral. The post-Step-7 profile shows GPU kernel time (83.6 ms/token) fully accounts for almost all of the 95.9 ms wall — host overhead is ~12 ms/token but is already overlapped with GPU work via the in-order queue's natural pipelining. The blocking readback was waiting for *GPU work to finish*, not for host work, and that wait is unavoidable. **Predicted +1.20–1.30× was wrong** — the openelm-270m gain was driven by a much higher relative host stall there. **Kept anyway**: code is clean, tokens match, and it interacts correctly with subsequent steps; reverting buys nothing.
+
+## Step 11 — `gemv_m1_k1024_no8_img` (3-run median, BIG WIN)
+
+**Lever.** New OpenCL kernel `gemv_m1_k1024_no8_img` in `kernels/gemv_m1.cl` — same image-backed K=1024 path as `_no4_img`, but produces **8 outputs per WG** instead of 4. Doubles per-thread arithmetic density (32 dot products + 36 vec4 reads per thread vs 16 + 20), giving the texture engine more in-flight reads to hide latency. Key insight: the BUFFER no4 path failed at K=1024 due to register pressure (Lever A in the Top-N table), but the IMAGE path uses the texture engine — a separate pipeline that doesn't compete for VGPRs the same way. Step 7 already established that no4 image works at K=1024 where no4 buffer doesn't; no8 image extends that headroom further.
+
+Dispatcher in `src/utils.cpp::run_gemv_m1_image` selects no8 when `K==1024 && N>=2048 && N%8==0`. Threshold N≥2048 avoids a small regression at N=512 / N=1024 where the WG count drops below the device's latency-hiding threshold (no8 → 8192 threads at N=1024 is too few; no4 keeps 16384). Larger sites win:
+
+| Site | Step 7 (no4) | Step 11 (no8) | Speedup | New BW utilization |
+|---|---|---|---|---|
+| K=1024 N=4608 (MLP w1/w3) | 1167 µs | **1033 µs** | **1.13×** | **68%** ↑ from 60% |
+| K=1024 N=65536 (lm_head, per tile) | 4078 µs | **3428 µs** | **1.19×** | **70%** ↑ from 58% |
+| K=1024 N=3072 (conv in_proj) | 789 µs | **718 µs** | **1.10×** | **65%** ↑ from 59% |
+| K=1024 N=1024 (q/conv-out/attn-out) | 284 µs | 290 µs | 0.98× | unchanged (uses no4) |
+| K=1024 N=512 (k/v_proj) | 157 µs | 174 µs | 0.90× | unchanged (uses no4) |
+| K=4608 N=1024 (MLP w2) | 822 µs | 732 µs | 1.12× | unchanged kernel (warm-thermal) |
+
+5-run measurement (post-build warmup):
+
+| Run | decode tok/s | tokens deterministic |
+|---|---|---|
+| 1 | 11.21 | ✓ |
+| 2 | 11.21 | ✓ |
+| 3 | 10.75 | ✓ (thermal dip) |
+| 4 | 11.25 | ✓ |
+| 5 | 11.17 | ✓ |
+| **median** | **11.21** | ✓ |
+
+**Step 11 / Step 7 (10.21):** **1.098×.** Tokens are bit-identical to the locked Session-2 reference. Per-token decode time: 1000 / 11.21 = **89.2 ms/token** (down from 97.9). Effective decode BW: 676 MB / 89.2 ms = **7.58 GB/s = 56% of texture-cache ceiling** (up from 51%).
+
+**Why register pressure didn't bite at no8:** the K=1024 no4 buffer regression was diagnosed (line 171) as 25 fp32 regs/thread spilling. no8 image holds 8 fp32 acc + transient W vec4 + 1 x vec4 ≈ 50–60 fp32-equivalent regs. The IMAGE path's `read_imageh + convert_float4` apparently keeps W loads in texture-engine pipeline registers (separate from compute VGPRs), so the 8-output design fits where 4-output buffer didn't.
+
+## Step 11 ledger
+
+| Metric | Step 7 (session-2 final) | Step 11 (session-3) | Δ |
+|---|---|---|---|
+| Decode tok/s | 10.21 | **11.21** | **+9.8%** |
+| Decode ms/token | 97.9 | 89.2 | −8.7 ms |
+| Effective decode BW | 6.91 GB/s | 7.58 GB/s | +0.67 GB/s |
+| % of 13.46 GB/s texture ceiling | 51% | **56%** | +5 pp |
+| Tokens deterministic | ✓ | ✓ | ID-for-ID matched |
+
+**Cumulative session-3:** 10.21 → 11.21 = **1.098× = +9.8%.**
+
+## Step 12 — fused MLP (w3 GEMV + silu_mul) — sub-noise, NOT shipped
+
+**Lever.** New OpenCL kernel `gemv_m1_k1024_no8_silufused_img` in `kernels/mlp_fused.cl` (separate cl_program — see *Compiler interaction caveat* below). Replaces the second MLP GEMV + `silu_mul` with a single kernel that reads `buf_gate_[n]` (= w1·x from a prior pytorch_linear), reads W3 via image2d, and writes `silu(buf_gate_[n]) * (W3·x)` back into buf_gate_. Eliminates one kernel launch per MLP layer (16/token) and the buf_up_ intermediate buffer entirely.
+
+**Compiler interaction caveat (recorded for posterity).** First attempt placed the silufused kernel inside `kernels/gemv_m1.cl`. Result: catastrophic 13× per-call regression on the no8 kernels (no8 K=1024,N=4608 went 1032 → 13217 µs; whole-program tok/s dropped from 11.21 → 1.32). Hypothesis: Adreno OpenCL compiler runs cross-kernel global register allocation across all kernels in a cl_program, and the silufused kernel's transient state (8 acc + native_exp + gate read/write) pushed the no8 kernels' allocation over the per-wave register file budget, causing them to spill. **Lesson: keep optimizer-sensitive kernels in their own cl_program on Adreno.** Moved silufused to `kernels/mlp_fused.cl` with its own `ensure_mlp_fused_program()`; no8 kernels recovered to 1032 µs.
+
+**Per-call profile (post-fix, separate program):**
+- `gemv_m1_K1024_N4608_no8_img` (w1 GEMV alone): 1032 µs/call
+- `gemv_m1_K1024_no8_silufused_img` (w3 + silu, fused): **881 µs/call** ← *slightly faster than the bare no8 GEMV*
+- Net per layer: 1032 + 881 = 1913 µs vs unfused 2 × 1033 + 15 silu = 2081 µs → ~170 µs saved per MLP × 16 = **2.7 ms/token GPU saved**
+
+**Wall-clock measurement (12 runs across two clean rebuilds):** 10.87, 10.91, 10.98, 10.98, 10.99, 10.99, 11.00, 11.00, 11.02, 11.03, 11.03 → median **10.99 tok/s**.
+
+| State | median tok/s |
+|---|---|
+| Step 11 (no fused) | 11.21 |
+| Step 12 (fused enabled) | 10.99 |
+| Step 12 code present, fused disabled in mlp.cpp | 11.21 |
+
+**Status:** ❌ NOT shipped (sub-noise to slight regression on Adreno 620; 2.7 ms GPU savings did not propagate to wall-clock, suggesting the in-order queue's natural pipelining was already absorbing the silu_mul cost). Kernel + program plumbing kept in tree (`kernels/mlp_fused.cl`, `pytorch_linear_silu_gate_fused()` in utils) — flip the `if (false)` guard in `Mlp::forward()` to re-enable for future driver/SDK comparison.
+
+## Session 3 final state
+
+| Metric | Step 7 baseline (session-2 final) | Step 11 final | Δ |
+|---|---|---|---|
+| Decode tok/s | 10.21 | **11.21** | **+9.8%** |
+| Decode ms/token | 97.9 | 89.2 | −8.7 ms |
+| Effective decode BW | 6.91 GB/s | 7.58 GB/s | +0.67 GB/s |
+| % of 13.46 GB/s texture ceiling | 51% | **56%** | +5 pp |
+| Tokens deterministic | ✓ | ✓ | ID-for-ID matched |
+
+**Path to 15 tok/s — what's needed:**
+- 15 tok/s = 66.7 ms/token wall = 75% of texture ceiling. Need to save another 22.5 ms/token from the current 89.2.
+- Per-shape utilization at Step 11 close: K=1024 sites at 65–70% (no8_img), K=4608 site at 85% (no4_img is already optimal). If K=1024 could match K=4608's 85%, savings would be ~10 ms/token → 13 tok/s. **Still short of 15.**
+- The remaining gap is fundamental: per-token weight footprint (676 MB) ÷ texture-cache ceiling (13.46 GB/s) = 50.2 ms/token = 19.9 tok/s ABSOLUTE max. The only path to 15 tok/s is **int8 weight quantization** (halves weight bytes → ~22 tok/s ceiling) — out of scope for this sprint.
+- Cheap remaining levers (Step 13 vec4 OperatorNorm, Step 14 conv-block kernel reduction) collectively offer ≤1% — not worth the complexity at this stage.
+
+## Repo state — session 3
+
+- `src/layers/embedding.{h,cpp}` — added `forward_from_device_token(queue, token_ids_dev, dev_offset_bytes)` for chained decode (reads token id from a GPU buffer instead of host array). Reuses existing persistent buf_input_ids_ / buf_out_.
+- `src/model.{h,cpp}` — added `forward_greedy_chained_enqueue(start_pos)` mirroring forward_greedy at seq_len=1 with no host readback; `Model::generate()` greedy fast path now runs a ping-pong async-readback loop after prefill (Step 10).
+- `kernels/gemv_m1.cl` — added `gemv_m1_k1024_no8_img` (Step 11). 8-output-per-WG image2d kernel. Selected by `run_gemv_m1_image()` for K=1024 ∧ N≥2048 ∧ N%8==0.
+- `src/utils.cpp` — registered `s_gemv_m1_k1024_no8_img`; threshold N≥2048 to fall back to no4_img on small-N sites; added `pytorch_linear_silu_gate_fused()` (Step 12) gated behind `seq_len==1` (currently dispatch is disabled in mlp.cpp pending wall-clock validation).
+- `src/utils.cpp` — added `ensure_mlp_fused_program()` building `kernels/mlp_fused.cl` as a SEPARATE cl_program (see Step 12 compiler interaction caveat).
+- `kernels/mlp_fused.cl` — new file with `gemv_m1_k1024_no8_silufused_img`. Lives in its own program to avoid Adreno's global cross-kernel register allocator spilling no8 in gemv_m1.cl.
+- `BENCHMARK.md` — Session 3 entries (this section).
+
+## Repo state
+
+- `src/main.cpp` — added `--no-eos` / `--ignore-eos` flag for benchmark continuation past the model's tokenizer-mismatched EOS=2.
+
 ## Repo state
 
 - `src/main.cpp` — added `--no-eos` / `--ignore-eos` flag for benchmark continuation past the model's tokenizer-mismatched EOS=2.

--- a/src/models/lfm2-5-350m/kernels/attention.cl
+++ b/src/models/lfm2-5-350m/kernels/attention.cl
@@ -160,3 +160,21 @@ __kernel void gqa_attn_out(
   STORE(out, out_idx + 3, acc3);
 #endif
 }
+
+
+// kv_write — single-row append into the persistent KV cache. Replaces the
+// non-recordable clEnqueueCopyBuffer used in attention.cpp's decode path so
+// the entire forward pass can be captured by cl_qcom_recordable_queues.
+// Only NDRangeKernel is recordable per Snapdragon Programming Guide §9.1.3.
+//
+// One work-item per element in the row. Launch with gws=kv_dim, lws=64
+// (kv_dim is a multiple of 64 in LFM2 — KVH*D = 8*64 = 512).
+__kernel void kv_write(
+    __global const storage_t* src,
+    __global storage_t* cache,
+    const int start_pos,
+    const int kv_dim) {
+  const int gid = (int)get_global_id(0);
+  if (gid >= kv_dim) return;
+  STORE(cache, start_pos * kv_dim + gid, LOAD(src, gid));
+}

--- a/src/models/lfm2-5-350m/kernels/convolution.cl
+++ b/src/models/lfm2-5-350m/kernels/convolution.cl
@@ -182,3 +182,62 @@ __kernel void conv_mul_C(
   if (gid >= total) return;
   STORE(y, gid, LOAD(C, gid) * LOAD(conv, gid));
 }
+
+
+// ─────────────────────────────────────────────────────────────────────────
+// conv_block_decode — fused per-channel kernel for seq_len==1 (decode).
+//
+// Replaces this 7-launch sequence (per layer × 10 conv layers × 32 tokens
+// = 2240 dispatches in a 32-token decode):
+//   conv_copy_transpose / conv_split_chunk3 / conv_pointwise_mul (Bx) /
+//   conv1d_causal_with_cache / conv_copy_transpose_back_state /
+//   conv_update_state / conv_mul_C / conv_copy_transpose_back
+// with ONE kernel: 1 work-item per channel does B/C/X read, Bx, conv1d
+// against `state` and conv_w, multiply by C, write y_out, then shift+append
+// the state for the next step.
+//
+// For seq_len=1 the four transpose steps in the unfused path are no-ops
+// (single-token tensors don't reshape), so collapsing everything into a
+// per-channel kernel produces bit-identical math while killing 80
+// kernel launches and 6 intermediate buffers' worth of L2 traffic per
+// decoded token.
+//
+// Launch: gws=H, lws=64.
+__kernel void conv_block_decode(
+    __global const storage_t* in_proj,    // [3H]: B(H) | C(H) | X(H)
+    __global const storage_t* conv_w,     // [H, L]
+    __global storage_t* state,            // [H, L-1]; read prev, write updated
+    __global storage_t* y_out,            // [H]
+    const int H,
+    const int L) {
+  const int c = (int)get_global_id(0);
+  if (c >= H) return;
+
+  const float B  = LOAD(in_proj, c);
+  const float C  = LOAD(in_proj, H + c);
+  const float X  = LOAD(in_proj, 2 * H + c);
+  const float Bx = B * X;
+
+  const int state_len = L - 1;
+  const int wbase = c * L;
+  const int sbase = c * state_len;
+
+  // Read state into a small local array — used both for the conv1d MAC
+  // below AND for the in-place state shift after. Capped at 8 (covers
+  // any practical kernel size).
+  float state_buf[8];
+  float acc = 0.0f;
+  for (int j = 0; j < state_len; ++j) {
+    state_buf[j] = LOAD(state, sbase + j);
+    acc += state_buf[j] * LOAD(conv_w, wbase + j);
+  }
+  acc += Bx * LOAD(conv_w, wbase + state_len);  // wbase + (L-1)
+
+  STORE(y_out, c, C * acc);
+
+  // Shift state left by 1, append Bx at the new tail.
+  for (int j = 0; j + 1 < state_len; ++j) {
+    STORE(state, sbase + j, state_buf[j + 1]);
+  }
+  STORE(state, sbase + state_len - 1, Bx);
+}

--- a/src/models/lfm2-5-350m/kernels/gemv_m1.cl
+++ b/src/models/lfm2-5-350m/kernels/gemv_m1.cl
@@ -379,6 +379,77 @@ void gemv_m1_k1024_no2_img(
   }
 }
 
+// K=1024, image-backed W, 8 outputs per WG. WG=64.
+// Doubles the per-thread arithmetic density vs no4 (32 dot products vs 16),
+// which gives the texture engine more in-flight reads to hide latency.
+// Required because K=1024 no4_img stalls at ~60% of texture ceiling (vs
+// K=4608 no4_img at 85%) — the difference is exactly per-thread work count.
+//
+// Per thread: 4 K-iterations × (1 x vec4 + 8 W vec4) = 36 vec4 reads = 288 B.
+// Register: 8 fp32 acc + 9 fp16x4 in flight = ~50 fp32-equivalent regs. Fits
+// the wave's register file in the image path (the texture engine has its
+// own pipeline that doesn't compete for VGPRs the way buffer reads do).
+__kernel
+__attribute__((reqd_work_group_size(64, 1, 1)))
+void gemv_m1_k1024_no8_img(
+    __global const storage_t* x,
+    __read_only image2d_t W_img,
+    __global storage_t* out,
+    const int N) {
+  const int n_base = (int)get_group_id(0) * 8;
+  const int tid    = (int)get_local_id(0);
+  if (n_base >= N) return;
+
+  __local float partial[8][64];
+  __global const half* xh = (__global const half*)x;
+  float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+  float acc4 = 0.0f, acc5 = 0.0f, acc6 = 0.0f, acc7 = 0.0f;
+
+  #pragma unroll
+  for (int j = 0; j < 4; ++j) {
+    const int x_off = j * (64 * 4) + tid * 4;
+    const int pix   = j * 64 + tid;
+    float4 xv = vload_half4(0, xh + x_off);
+    float4 w0 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 0)));
+    float4 w1 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 1)));
+    float4 w2 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 2)));
+    float4 w3 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 3)));
+    float4 w4 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 4)));
+    float4 w5 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 5)));
+    float4 w6 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 6)));
+    float4 w7 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 7)));
+    acc0 += dot(xv, w0); acc1 += dot(xv, w1);
+    acc2 += dot(xv, w2); acc3 += dot(xv, w3);
+    acc4 += dot(xv, w4); acc5 += dot(xv, w5);
+    acc6 += dot(xv, w6); acc7 += dot(xv, w7);
+  }
+  partial[0][tid] = acc0; partial[1][tid] = acc1;
+  partial[2][tid] = acc2; partial[3][tid] = acc3;
+  partial[4][tid] = acc4; partial[5][tid] = acc5;
+  partial[6][tid] = acc6; partial[7][tid] = acc7;
+  barrier(CLK_LOCAL_MEM_FENCE);
+  for (int s = 32; s > 0; s >>= 1) {
+    if (tid < s) {
+      partial[0][tid] += partial[0][tid + s]; partial[1][tid] += partial[1][tid + s];
+      partial[2][tid] += partial[2][tid + s]; partial[3][tid] += partial[3][tid + s];
+      partial[4][tid] += partial[4][tid + s]; partial[5][tid] += partial[5][tid + s];
+      partial[6][tid] += partial[6][tid + s]; partial[7][tid] += partial[7][tid + s];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+  if (tid == 0) {
+    __global half* oh = (__global half*)out;
+    vstore_half(partial[0][0], 0, oh + n_base + 0);
+    vstore_half(partial[1][0], 0, oh + n_base + 1);
+    vstore_half(partial[2][0], 0, oh + n_base + 2);
+    vstore_half(partial[3][0], 0, oh + n_base + 3);
+    vstore_half(partial[4][0], 0, oh + n_base + 4);
+    vstore_half(partial[5][0], 0, oh + n_base + 5);
+    vstore_half(partial[6][0], 0, oh + n_base + 6);
+    vstore_half(partial[7][0], 0, oh + n_base + 7);
+  }
+}
+
 // K=4608, image-backed W, 4 outputs per WG. WG=64.
 // Inner loop: 18 wave-stride vec4 iterations × 64 threads = 1152 vec4 = 4608 fp16.
 __kernel

--- a/src/models/lfm2-5-350m/kernels/gemv_m1.cl
+++ b/src/models/lfm2-5-350m/kernels/gemv_m1.cl
@@ -29,6 +29,17 @@
   #define STORE(p, i, v) ((p)[(i)] = (v))
 #endif
 
+// EXPERIMENT (2026-05-07, lfm2): tried sub_group_reduce_add with
+// qcom_reqd_sub_group_size("full") to replace the local-mem tree reduce.
+// With the attribute, tokens were ID-for-ID correct but the kernels
+// regressed 7× (11.2 → 1.5 tok/s) — full-wave forcing on a 50-fp32-acc
+// no8_img kernel either spilled registers or halved active lanes when
+// wave_size > 64. Without the attribute, sub_group_reduce_add with the
+// compiler's heuristic-picked subgroup size produced wrong tokens (only
+// half-wave summed, leaving GEMV outputs at ~1/2 of true value). Reverted;
+// the existing barrier-tree reduce stays — it's intra-wave on WG=64 so
+// the barriers compile to ~no-ops.
+
 #ifndef WG_SIZE
 #define WG_SIZE 64
 #endif
@@ -303,7 +314,6 @@ void gemv_m1_k1024_no4_img(
   const int tid    = (int)get_local_id(0);
   if (n_base >= N) return;
 
-  __local float partial[4][64];
   __global const half* xh = (__global const half*)x;
   float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
 
@@ -319,6 +329,7 @@ void gemv_m1_k1024_no4_img(
     acc0 += dot(xv, w0); acc1 += dot(xv, w1);
     acc2 += dot(xv, w2); acc3 += dot(xv, w3);
   }
+  __local float partial[4][64];
   partial[0][tid] = acc0; partial[1][tid] = acc1;
   partial[2][tid] = acc2; partial[3][tid] = acc3;
   barrier(CLK_LOCAL_MEM_FENCE);
@@ -351,7 +362,6 @@ void gemv_m1_k1024_no2_img(
   const int tid    = (int)get_local_id(0);
   if (n_base >= N) return;
 
-  __local float partial[2][64];
   __global const half* xh = (__global const half*)x;
   float acc0 = 0.0f, acc1 = 0.0f;
 
@@ -364,6 +374,7 @@ void gemv_m1_k1024_no2_img(
     float4 w1 = convert_float4(read_imageh(W_img, kImgSampler, (int2)(pix, n_base + 1)));
     acc0 += dot(xv, w0); acc1 += dot(xv, w1);
   }
+  __local float partial[2][64];
   partial[0][tid] = acc0; partial[1][tid] = acc1;
   barrier(CLK_LOCAL_MEM_FENCE);
   for (int s = 32; s > 0; s >>= 1) {
@@ -389,10 +400,17 @@ void gemv_m1_k1024_no2_img(
 // Register: 8 fp32 acc + 9 fp16x4 in flight = ~50 fp32-equivalent regs. Fits
 // the wave's register file in the image path (the texture engine has its
 // own pipeline that doesn't compete for VGPRs the way buffer reads do).
+// EXPERIMENT (lever #4 from Adreno OpenCL guide §6.4 / §7.1.3): promote
+// the activation x to on-chip __constant memory. x is 1024 fp16 = 2048 B,
+// well under the per-kernel constant cache budget. Each K-iteration reads
+// the same x[off..off+3] vec4 across all 64 lanes — exactly the
+// "uniform broadcast" pattern the constant cache is designed for ("can
+// broadcast into ALUs in no time"). Without max_constant_size the compiler
+// falls back to off-chip system memory.
 __kernel
 __attribute__((reqd_work_group_size(64, 1, 1)))
 void gemv_m1_k1024_no8_img(
-    __global const storage_t* x,
+    __constant storage_t* x __attribute__((max_constant_size(2048))),
     __read_only image2d_t W_img,
     __global storage_t* out,
     const int N) {
@@ -400,8 +418,7 @@ void gemv_m1_k1024_no8_img(
   const int tid    = (int)get_local_id(0);
   if (n_base >= N) return;
 
-  __local float partial[8][64];
-  __global const half* xh = (__global const half*)x;
+  __constant const half* xh = (__constant const half*)x;
   float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
   float acc4 = 0.0f, acc5 = 0.0f, acc6 = 0.0f, acc7 = 0.0f;
 
@@ -423,6 +440,7 @@ void gemv_m1_k1024_no8_img(
     acc4 += dot(xv, w4); acc5 += dot(xv, w5);
     acc6 += dot(xv, w6); acc7 += dot(xv, w7);
   }
+  __local float partial[8][64];
   partial[0][tid] = acc0; partial[1][tid] = acc1;
   partial[2][tid] = acc2; partial[3][tid] = acc3;
   partial[4][tid] = acc4; partial[5][tid] = acc5;
@@ -463,7 +481,6 @@ void gemv_m1_k4608_no4_img(
   const int tid    = (int)get_local_id(0);
   if (n_base >= N) return;
 
-  __local float partial[4][64];
   __global const half* xh = (__global const half*)x;
   float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
 
@@ -479,6 +496,7 @@ void gemv_m1_k4608_no4_img(
     acc0 += dot(xv, w0); acc1 += dot(xv, w1);
     acc2 += dot(xv, w2); acc3 += dot(xv, w3);
   }
+  __local float partial[4][64];
   partial[0][tid] = acc0; partial[1][tid] = acc1;
   partial[2][tid] = acc2; partial[3][tid] = acc3;
   barrier(CLK_LOCAL_MEM_FENCE);
@@ -564,3 +582,10 @@ void gemv_stream_img(
 }
 
 #endif  // USE_FP16
+
+// Tiny kernel for the recordable-queues probe (cl_qcom_recordable_queues).
+// Does almost nothing per dispatch so per-launch CPU overhead dominates,
+// exposing any bookkeeping savings the recording API provides.
+__kernel void probe_noop(__global int* counter, const int incr) {
+  if (get_global_id(0) == 0) atomic_add(counter, incr);
+}

--- a/src/models/lfm2-5-350m/kernels/mlp_fused.cl
+++ b/src/models/lfm2-5-350m/kernels/mlp_fused.cl
@@ -1,0 +1,73 @@
+// MLP w3 GEMV + silu_mul fused into one kernel. Reads gate_inout[n] (= w1·x
+// from a prior pytorch_linear call), reads W3 via image2d, computes
+// silu(gate_inout[n]) * (W3·x), writes the result back into gate_inout.
+//
+// Lives in its own .cl file (separate cl_program) on purpose: putting this
+// kernel in gemv_m1.cl caused the Adreno compiler to spill registers in the
+// other no8_img kernels (presumably global cross-kernel register pressure
+// analysis), regressing the decode rate by ~10× on Adreno 620. Compiling it
+// as a standalone program isolates the allocation.
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+__constant sampler_t kImgSampler =
+    CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST;
+
+// K=1024, image-backed W3, 8 outputs per WG, fused silu_mul on writeback.
+__kernel
+__attribute__((reqd_work_group_size(64, 1, 1)))
+void gemv_m1_k1024_no8_silufused_img(
+    __global const half* x,
+    __read_only image2d_t W3_img,
+    __global half* gate_inout,
+    const int N) {
+  const int n_base = (int)get_group_id(0) * 8;
+  const int tid    = (int)get_local_id(0);
+  if (n_base >= N) return;
+
+  __local float partial[8][64];
+  float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+  float acc4 = 0.0f, acc5 = 0.0f, acc6 = 0.0f, acc7 = 0.0f;
+
+  #pragma unroll
+  for (int j = 0; j < 4; ++j) {
+    const int x_off = j * (64 * 4) + tid * 4;
+    const int pix   = j * 64 + tid;
+    float4 xv = vload_half4(0, x + x_off);
+    float4 w0 = convert_float4(read_imageh(W3_img, kImgSampler, (int2)(pix, n_base + 0)));
+    float4 w1 = convert_float4(read_imageh(W3_img, kImgSampler, (int2)(pix, n_base + 1)));
+    float4 w2 = convert_float4(read_imageh(W3_img, kImgSampler, (int2)(pix, n_base + 2)));
+    float4 w3 = convert_float4(read_imageh(W3_img, kImgSampler, (int2)(pix, n_base + 3)));
+    float4 w4 = convert_float4(read_imageh(W3_img, kImgSampler, (int2)(pix, n_base + 4)));
+    float4 w5 = convert_float4(read_imageh(W3_img, kImgSampler, (int2)(pix, n_base + 5)));
+    float4 w6 = convert_float4(read_imageh(W3_img, kImgSampler, (int2)(pix, n_base + 6)));
+    float4 w7 = convert_float4(read_imageh(W3_img, kImgSampler, (int2)(pix, n_base + 7)));
+    acc0 += dot(xv, w0); acc1 += dot(xv, w1);
+    acc2 += dot(xv, w2); acc3 += dot(xv, w3);
+    acc4 += dot(xv, w4); acc5 += dot(xv, w5);
+    acc6 += dot(xv, w6); acc7 += dot(xv, w7);
+  }
+  partial[0][tid] = acc0; partial[1][tid] = acc1;
+  partial[2][tid] = acc2; partial[3][tid] = acc3;
+  partial[4][tid] = acc4; partial[5][tid] = acc5;
+  partial[6][tid] = acc6; partial[7][tid] = acc7;
+  barrier(CLK_LOCAL_MEM_FENCE);
+  for (int s = 32; s > 0; s >>= 1) {
+    if (tid < s) {
+      partial[0][tid] += partial[0][tid + s]; partial[1][tid] += partial[1][tid + s];
+      partial[2][tid] += partial[2][tid + s]; partial[3][tid] += partial[3][tid + s];
+      partial[4][tid] += partial[4][tid + s]; partial[5][tid] += partial[5][tid + s];
+      partial[6][tid] += partial[6][tid + s]; partial[7][tid] += partial[7][tid + s];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+  if (tid == 0) {
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const float w3x  = partial[i][0];
+      const float gate = vload_half(0, gate_inout + n_base + i);
+      const float sig  = 1.0f / (1.0f + native_exp(-gate));
+      vstore_half(gate * sig * w3x, 0, gate_inout + n_base + i);
+    }
+  }
+}

--- a/src/models/lfm2-5-350m/src/layers/attention.cpp
+++ b/src/models/lfm2-5-350m/src/layers/attention.cpp
@@ -37,6 +37,7 @@ Attention::~Attention() {
     if (scores_kernel_) clReleaseKernel(scores_kernel_);
     if (softmax_kernel_) clReleaseKernel(softmax_kernel_);
     if (out_kernel_) clReleaseKernel(out_kernel_);
+    if (kv_write_kernel_) clReleaseKernel(kv_write_kernel_);
     if (attn_program_) clReleaseProgram(attn_program_);
     if (rmsnorm_kernel_) clReleaseKernel(rmsnorm_kernel_);
     if (rmsnorm_program_) clReleaseProgram(rmsnorm_program_);
@@ -242,6 +243,11 @@ bool Attention::initialize() {
         NNOPT_ERROR_FMT("clCreateKernel gqa_attn_out failed: %d", err);
         return false;
     }
+    kv_write_kernel_ = clCreateKernel(attn_program_, "kv_write", &err);
+    if (err != CL_SUCCESS || !kv_write_kernel_) {
+        NNOPT_ERROR_FMT("clCreateKernel kv_write failed: %d", err);
+        return false;
+    }
 
     // Per-head RMSNorm program/kernel — used for Lfm2 q_layernorm/k_layernorm
     // (modeling_lfm2.py:241-242,255-256), applied to per-head [head_dim] slices
@@ -352,13 +358,21 @@ cl_mem Attention::forward(cl_command_queue queue,
     //   contiguous, so dispatching rmsnorm with rows=seq_q*QH, cols=D normalizes
     //   each [head_dim]-vector, matching the PyTorch semantics exactly.
     {
-        auto apply_qk_norm = [&](cl_mem buf, cl_mem tmp, int rows, int cols, cl_mem w, const char* tag) -> bool {
+        // In-place rmsnorm: pass the same buffer as input AND output. Within
+        // each row, the kernel performs all reads (sum-of-squares + element
+        // load for write) before storing — and each thread strides over
+        // disjoint columns (lid + k*WG_SIZE), so no work-item ever reads a
+        // column another work-item has already written. Safe in-place ⇒ kills
+        // the per-call clEnqueueCopyBuffer (non-recordable). buf_q_norm_tmp_
+        // / buf_k_norm_tmp_ are now unused on this path; kept allocated for
+        // any future code that needs an out-of-place workspace.
+        auto apply_qk_norm = [&](cl_mem buf, int rows, int cols, cl_mem w, const char* tag) -> bool {
             const float eps = MODEL_CONFIG::NORM_EPS;
             cl_int e = CL_SUCCESS;
             int arg = 0;
             e  = clSetKernelArg(rmsnorm_kernel_, arg++, sizeof(cl_mem), &buf);
             e |= clSetKernelArg(rmsnorm_kernel_, arg++, sizeof(cl_mem), &w);
-            e |= clSetKernelArg(rmsnorm_kernel_, arg++, sizeof(cl_mem), &tmp);
+            e |= clSetKernelArg(rmsnorm_kernel_, arg++, sizeof(cl_mem), &buf);  // out = buf (in-place)
             e |= clSetKernelArg(rmsnorm_kernel_, arg++, sizeof(int), &rows);
             e |= clSetKernelArg(rmsnorm_kernel_, arg++, sizeof(int), &cols);
             e |= clSetKernelArg(rmsnorm_kernel_, arg++, sizeof(float), &eps);
@@ -369,14 +383,10 @@ cl_mem Attention::forward(cl_command_queue queue,
             e = clEnqueueNDRangeKernel(queue, rmsnorm_kernel_, 1, nullptr, &gws, &lws, 0, nullptr,
                                        KernelProfiler::event_for("attn_qk_rmsnorm"));
             if (e != CL_SUCCESS) { NNOPT_ERROR_FMT("%s dispatch failed: %d", tag, e); return false; }
-            // Copy normalized values back into the original q/k buffer.
-            const size_t bytes = (size_t)rows * (size_t)cols * sizeof(nnopt_storage_t);
-            e = clEnqueueCopyBuffer(queue, tmp, buf, 0, 0, bytes, 0, nullptr, nullptr);
-            if (e != CL_SUCCESS) { NNOPT_ERROR_FMT("%s copy back failed: %d", tag, e); return false; }
             return true;
         };
-        if (!apply_qk_norm(q, buf_q_norm_tmp_, seq_q * QH,  D, q_ln_w_, "q_layernorm")) return fail_qkv();
-        if (!apply_qk_norm(k, buf_k_norm_tmp_, seq_q * KVH, D, k_ln_w_, "k_layernorm")) return fail_qkv();
+        if (!apply_qk_norm(q, seq_q * QH,  D, q_ln_w_, "q_layernorm")) return fail_qkv();
+        if (!apply_qk_norm(k, seq_q * KVH, D, k_ln_w_, "k_layernorm")) return fail_qkv();
     }
     NNOPT_LAYER_CHECK_FMT("block%d_sub_attn_query_states_post_qnorm", layer_idx_, queue, q, (size_t)seq_q * Q_DIM);
     NNOPT_LAYER_CHECK_FMT("block%d_sub_attn_key_states_post_knorm",   layer_idx_, queue, k, (size_t)seq_q * KV_DIM);
@@ -423,7 +433,33 @@ cl_mem Attention::forward(cl_command_queue queue,
     NNOPT_LAYER_CHECK_FMT("block%d_sub_attn_key_states",   layer_idx_, queue, k, (size_t)seq_q * KV_DIM);
 
     // ── Append rotated K and V into the persistent cache at start_pos.
-    {
+    //
+    // Decode hot path (seq_q==1) uses a kv_write NDRange kernel so the
+    // dispatch is recordable by cl_qcom_recordable_queues — only
+    // clEnqueueNDRangeKernel can be inside a recording per Programming Guide
+    // §9.1.3. Prefill (seq_q>1) keeps clEnqueueCopyBuffer because one big
+    // contiguous copy is faster than seq_q × per-row kernel launches and
+    // prefill isn't on the recordable hot path.
+    if (seq_q == 1) {
+        auto kv_write = [&](cl_mem src, cl_mem cache, const char* tag) -> bool {
+            cl_int e = CL_SUCCESS;
+            int kv_dim_arg = KV_DIM;
+            e  = clSetKernelArg(kv_write_kernel_, 0, sizeof(cl_mem), &src);
+            e |= clSetKernelArg(kv_write_kernel_, 1, sizeof(cl_mem), &cache);
+            e |= clSetKernelArg(kv_write_kernel_, 2, sizeof(int),    &start_pos);
+            e |= clSetKernelArg(kv_write_kernel_, 3, sizeof(int),    &kv_dim_arg);
+            if (e != CL_SUCCESS) { NNOPT_ERROR_FMT("kv_write setArg %s: %d", tag, e); return false; }
+            const size_t WG = 64;
+            size_t gws = (size_t)KV_DIM;
+            size_t lws = WG;
+            e = clEnqueueNDRangeKernel(queue, kv_write_kernel_, 1, nullptr, &gws, &lws, 0, nullptr,
+                                       KernelProfiler::event_for("kv_write"));
+            if (e != CL_SUCCESS) { NNOPT_ERROR_FMT("kv_write dispatch %s: %d", tag, e); return false; }
+            return true;
+        };
+        if (!kv_write(k, k_cache_, "k")) return fail_qkv();
+        if (!kv_write(v, v_cache_, "v")) return fail_qkv();
+    } else {
         const size_t dst_off_bytes = (size_t)start_pos * (size_t)KV_DIM * sizeof(nnopt_storage_t);
         const size_t kv_bytes = (size_t)seq_q * (size_t)KV_DIM * sizeof(nnopt_storage_t);
         err = clEnqueueCopyBuffer(queue, k, k_cache_, 0, dst_off_bytes, kv_bytes, 0, nullptr, nullptr);

--- a/src/models/lfm2-5-350m/src/layers/attention.h
+++ b/src/models/lfm2-5-350m/src/layers/attention.h
@@ -55,6 +55,7 @@ private:
     cl_kernel scores_kernel_ = nullptr;
     cl_kernel softmax_kernel_ = nullptr;
     cl_kernel out_kernel_ = nullptr;
+    cl_kernel kv_write_kernel_ = nullptr;  // decode-only NDRange replacement for KV-cache copy
 
     // Per-head RMSNorm for query/key (Lfm2 q_layernorm/k_layernorm,
     // applied BEFORE RoPE on the head_dim axis).

--- a/src/models/lfm2-5-350m/src/layers/convolution.cpp
+++ b/src/models/lfm2-5-350m/src/layers/convolution.cpp
@@ -24,6 +24,7 @@ Convolution::~Convolution() {
   if (update_cache_kernel_) clReleaseKernel(update_cache_kernel_);
   if (elem_mul2_kernel_) clReleaseKernel(elem_mul2_kernel_);
   if (copy_transpose_back_kernel_) clReleaseKernel(copy_transpose_back_kernel_);
+  if (block_decode_kernel_) clReleaseKernel(block_decode_kernel_);
 
   if (conv_state_) clReleaseMemObject(conv_state_);
 
@@ -147,6 +148,11 @@ bool Convolution::initialize() {
     NNOPT_ERROR_FMT("Convolution[%d]: clCreateKernel(conv_copy_transpose_back) failed: %d", layer_idx_, (int)err);
     return false;
   }
+  block_decode_kernel_ = clCreateKernel(program_, "conv_block_decode", &err);
+  if (err != CL_SUCCESS || !block_decode_kernel_) {
+    NNOPT_ERROR_FMT("Convolution[%d]: clCreateKernel(conv_block_decode) failed: %d", layer_idx_, (int)err);
+    return false;
+  }
 
   // conv_state_ stores last (L-1) Bx values for each channel.
   // Layout: [hidden, L-1]
@@ -191,6 +197,36 @@ cl_mem Convolution::forward(cl_command_queue queue, cl_mem hidden_states, int se
 
   // 1) in_proj: [seq,H] -> [seq,3H]  (writes buf_in_proj_)
   pytorch_linear(queue, seq_len, 3 * H, H, hidden_states, in_proj_w_, buf_in_proj_);
+
+  // ── Decode fast path (seq_len == 1): one fused kernel collapses the next
+  // 7 launches (transposes are no-ops at S=1; split / Bx-mul / conv1d /
+  // state-update / mul-by-C all reduce to per-channel work). Keeps prefill
+  // and any seq_q>1 call on the canonical multi-launch path below for
+  // correctness.
+  if (seq_len == 1 && conv_state_ && (l_cache_ - 1) > 0) {
+    cl_int e = CL_SUCCESS;
+    int H_arg = H;
+    int L_arg = l_cache_;
+    e  = clSetKernelArg(block_decode_kernel_, 0, sizeof(cl_mem), &buf_in_proj_);
+    e |= clSetKernelArg(block_decode_kernel_, 1, sizeof(cl_mem), &conv_w_);
+    e |= clSetKernelArg(block_decode_kernel_, 2, sizeof(cl_mem), &conv_state_);
+    e |= clSetKernelArg(block_decode_kernel_, 3, sizeof(cl_mem), &buf_y_seq_);
+    e |= clSetKernelArg(block_decode_kernel_, 4, sizeof(int),    &H_arg);
+    e |= clSetKernelArg(block_decode_kernel_, 5, sizeof(int),    &L_arg);
+    if (e != CL_SUCCESS) { NNOPT_ERROR_FMT("Convolution[%d]: setArgs(block_decode): %d", layer_idx_, e); return nullptr; }
+    const size_t WG = 64;
+    size_t gws = (size_t)((H + WG - 1) / WG) * WG;  // round-up to lws multiple
+    size_t lws = WG;
+    e = clEnqueueNDRangeKernel(queue, block_decode_kernel_, 1, nullptr, &gws, &lws, 0, nullptr,
+                               KernelProfiler::event_for("conv_block_decode"));
+    if (e != CL_SUCCESS) { NNOPT_ERROR_FMT("Convolution[%d]: dispatch(block_decode): %d", layer_idx_, e); return nullptr; }
+
+    // out_proj: buf_y_seq_ -> buf_out_
+    if (!pytorch_linear(queue, seq_len, H, H, buf_y_seq_, out_proj_w_, buf_out_)) return nullptr;
+    NNOPT_LAYER_CHECK_FMT("conv_%d", layer_idx_, queue, buf_out_, (size_t)seq_len * (size_t)H);
+    (void)start_pos;
+    return buf_out_;
+  }
 
   // 2) transpose buf_in_proj_ -> buf_in_proj_T_: [3H, seq]
   {

--- a/src/models/lfm2-5-350m/src/layers/convolution.h
+++ b/src/models/lfm2-5-350m/src/layers/convolution.h
@@ -32,6 +32,7 @@ private:
   cl_kernel update_cache_kernel_ = nullptr;       // update ring/shift cache
   cl_kernel elem_mul2_kernel_ = nullptr;          // Y = C * conv_out
   cl_kernel copy_transpose_back_kernel_ = nullptr; // [hidden, seq] -> [seq, hidden]
+  cl_kernel block_decode_kernel_ = nullptr;        // fused per-channel kernel for seq_len==1
 
   // persistent conv state cache: [hidden, L_cache-1]
   cl_mem conv_state_ = nullptr;

--- a/src/models/lfm2-5-350m/src/layers/embedding.cpp
+++ b/src/models/lfm2-5-350m/src/layers/embedding.cpp
@@ -105,14 +105,20 @@ cl_mem Embedding::forward_from_device_token(cl_command_queue queue, cl_mem token
     buf_seq_capacity_ = 1;
   }
 
-  // Pull the single int32 token id from the device-side buffer.
-  err = clEnqueueCopyBuffer(queue, token_ids_dev, buf_input_ids_,
-                            dev_offset_bytes, 0, sizeof(int), 0, nullptr, nullptr);
-  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Embedding(chained): copy token id: %d", err); return nullptr; }
+  // Bind the device-side token-id buffer directly as kernel arg 0 when there
+  // is no offset — saves a clEnqueueCopyBuffer (non-recordable) per token.
+  // Falls back to the copy path when an offset is required.
+  cl_mem ids_arg = token_ids_dev;
+  if (dev_offset_bytes != 0) {
+    err = clEnqueueCopyBuffer(queue, token_ids_dev, buf_input_ids_,
+                              dev_offset_bytes, 0, sizeof(int), 0, nullptr, nullptr);
+    if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Embedding(chained): copy token id: %d", err); return nullptr; }
+    ids_arg = buf_input_ids_;
+  }
 
   int hidden = MODEL_CONFIG::HIDDEN_SIZE;
   int seq_len = 1;
-  err  = clSetKernelArg(kernel_, 0, sizeof(cl_mem), &buf_input_ids_);
+  err  = clSetKernelArg(kernel_, 0, sizeof(cl_mem), &ids_arg);
   err |= clSetKernelArg(kernel_, 1, sizeof(cl_mem), &embed_w_);
   err |= clSetKernelArg(kernel_, 2, sizeof(cl_mem), &buf_out_);
   err |= clSetKernelArg(kernel_, 3, sizeof(int),    &seq_len);

--- a/src/models/lfm2-5-350m/src/layers/embedding.cpp
+++ b/src/models/lfm2-5-350m/src/layers/embedding.cpp
@@ -84,3 +84,44 @@ cl_mem Embedding::forward(cl_command_queue queue, const int* input_ids, int seq_
   NNOPT_DEBUG_SYNC(queue);
   return buf_out_;  // BORROWED
 }
+
+cl_mem Embedding::forward_from_device_token(cl_command_queue queue, cl_mem token_ids_dev,
+                                            size_t dev_offset_bytes) {
+  if (!kernel_ || !embed_w_) return nullptr;
+  if (!token_ids_dev) return nullptr;
+
+  cl_context ctx = cl_ctx_.context();
+  cl_int err = CL_SUCCESS;
+
+  // Reuse the same persistent buffers as forward(). Ensure capacity for 1.
+  if (buf_seq_capacity_ < 1 || !buf_out_) {
+    if (buf_out_) { clReleaseMemObject(buf_out_); buf_out_ = nullptr; }
+    if (buf_input_ids_) { clReleaseMemObject(buf_input_ids_); buf_input_ids_ = nullptr; }
+    buf_out_ = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+                              (size_t)MODEL_CONFIG::HIDDEN_SIZE * sizeof(nnopt_storage_t), nullptr, &err);
+    if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Embedding(chained): alloc buf_out: %d", err); return nullptr; }
+    buf_input_ids_ = clCreateBuffer(ctx, CL_MEM_READ_WRITE, sizeof(int), nullptr, &err);
+    if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Embedding(chained): alloc buf_input_ids: %d", err); return nullptr; }
+    buf_seq_capacity_ = 1;
+  }
+
+  // Pull the single int32 token id from the device-side buffer.
+  err = clEnqueueCopyBuffer(queue, token_ids_dev, buf_input_ids_,
+                            dev_offset_bytes, 0, sizeof(int), 0, nullptr, nullptr);
+  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Embedding(chained): copy token id: %d", err); return nullptr; }
+
+  int hidden = MODEL_CONFIG::HIDDEN_SIZE;
+  int seq_len = 1;
+  err  = clSetKernelArg(kernel_, 0, sizeof(cl_mem), &buf_input_ids_);
+  err |= clSetKernelArg(kernel_, 1, sizeof(cl_mem), &embed_w_);
+  err |= clSetKernelArg(kernel_, 2, sizeof(cl_mem), &buf_out_);
+  err |= clSetKernelArg(kernel_, 3, sizeof(int),    &seq_len);
+  err |= clSetKernelArg(kernel_, 4, sizeof(int),    &hidden);
+  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Embedding(chained): setArgs: %d", err); return nullptr; }
+
+  size_t gws[1] = {1};
+  err = clEnqueueNDRangeKernel(queue, kernel_, 1, nullptr, gws, nullptr, 0, nullptr,
+                               KernelProfiler::event_for("embedding_chained"));
+  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Embedding(chained): enqueue: %d", err); return nullptr; }
+  return buf_out_;  // BORROWED
+}

--- a/src/models/lfm2-5-350m/src/layers/embedding.h
+++ b/src/models/lfm2-5-350m/src/layers/embedding.h
@@ -17,6 +17,13 @@ public:
   // Returns [seq_len, hidden]
   cl_mem forward(cl_command_queue queue, const int* input_ids, int seq_len);
 
+  // Step 10: chained-decode variant. Reads a single int32 token id from a
+  // GPU-side buffer at byte offset `dev_offset_bytes` (typically the
+  // previous iteration's argmax output) instead of taking host ids. Always
+  // seq_len=1 at decode. Returns [1, hidden] BORROWED.
+  cl_mem forward_from_device_token(cl_command_queue queue, cl_mem token_ids_dev,
+                                   size_t dev_offset_bytes);
+
 private:
   OpenCLContext& cl_ctx_;
   Weights& weights_;

--- a/src/models/lfm2-5-350m/src/layers/mlp.cpp
+++ b/src/models/lfm2-5-350m/src/layers/mlp.cpp
@@ -99,19 +99,32 @@ cl_mem Mlp::forward(cl_command_queue queue, cl_mem x, int seq_len) {
 
   // gate = w1(x)  → buf_gate_
   if (!pytorch_linear(queue, seq_len, I, H, x, w1_, buf_gate_)) return nullptr;
-  // up = w3(x)    → buf_up_
-  if (!pytorch_linear(queue, seq_len, I, H, x, w3_, buf_up_))   return nullptr;
-  // buf_gate_ = silu(buf_gate_) * buf_up_
-  const int total = seq_len * I;
-  if (!set_arg_checked(silu_mul_kernel_, 0, sizeof(cl_mem), &buf_gate_, "a") ||
-      !set_arg_checked(silu_mul_kernel_, 1, sizeof(cl_mem), &buf_up_,   "b") ||
-      !set_arg_checked(silu_mul_kernel_, 2, sizeof(cl_mem), &buf_gate_, "out") ||
-      !set_arg_checked(silu_mul_kernel_, 3, sizeof(int),    &total,     "n")) return nullptr;
-  size_t gws[1] = {(size_t)total};
-  cl_int err = clEnqueueNDRangeKernel(queue, silu_mul_kernel_, 1, nullptr, gws, nullptr, 0, nullptr,
-                                      KernelProfiler::event_for("silu_mul"));
-  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Mlp[%d]: silu_mul: %d", layer_idx_, err); return nullptr; }
-  NNOPT_DEBUG_SYNC(queue);
+
+  // Step 12 fast path (M=1 decode only, K=1024, N%8==0): fuse w3 GEMV with the
+  // silu_mul on the writeback. Reads gate (=w1·x) inline, computes
+  // silu(gate)*(w3·x), writes back into buf_gate_. Eliminates one silu_mul
+  // kernel launch and the buf_up_ intermediate buffer per MLP layer.
+  bool fused_ok = false;
+  if (false) {  // Step 12 fused path: gain was sub-noise on Adreno 620
+                // (median 10.99 vs Step 11 11.21). Keep code for re-eval but
+                // don't ship the dispatch.
+    fused_ok = pytorch_linear_silu_gate_fused(queue, I, H, x, w3_, buf_gate_);
+  }
+  if (!fused_ok) {
+    // Fallback: separate w3 GEMV + silu_mul (prefill or non-eligible shapes).
+    if (!pytorch_linear(queue, seq_len, I, H, x, w3_, buf_up_)) return nullptr;
+    const int total = seq_len * I;
+    if (!set_arg_checked(silu_mul_kernel_, 0, sizeof(cl_mem), &buf_gate_, "a") ||
+        !set_arg_checked(silu_mul_kernel_, 1, sizeof(cl_mem), &buf_up_,   "b") ||
+        !set_arg_checked(silu_mul_kernel_, 2, sizeof(cl_mem), &buf_gate_, "out") ||
+        !set_arg_checked(silu_mul_kernel_, 3, sizeof(int),    &total,     "n")) return nullptr;
+    size_t gws[1] = {(size_t)total};
+    cl_int err = clEnqueueNDRangeKernel(queue, silu_mul_kernel_, 1, nullptr, gws, nullptr, 0, nullptr,
+                                        KernelProfiler::event_for("silu_mul"));
+    if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Mlp[%d]: silu_mul: %d", layer_idx_, err); return nullptr; }
+    NNOPT_DEBUG_SYNC(queue);
+  }
+
   // out = w2(gate)  → buf_out_
   if (!pytorch_linear(queue, seq_len, H, I, buf_gate_, w2_, buf_out_)) return nullptr;
   return buf_out_;  // BORROWED

--- a/src/models/lfm2-5-350m/src/main.cpp
+++ b/src/models/lfm2-5-350m/src/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed to initialize OpenCL" << std::endl;
         return 1;
     }
-    std::cerr << "Device: " << cl_ctx.device_name() << std::endl;
+    std::cerr << "Device: " << cl_ctx.device_description() << std::endl;
     NNOPT_CHECKPOINT("OpenCL initialized");
 
     // Bandwidth probe — exits before LLM work. Toggle with NNOPT_BW_PROBE=1.
@@ -391,8 +391,6 @@ int main(int argc, char* argv[]) {
 
     // Generate
     NNOPT_CHECKPOINT("starting generation");
-    Timer timer;
-    timer.start();
 
     // Print the prompt prefix (decoded back through the tokenizer for
     // round-trip parity), then stream each new token's text as it's
@@ -431,7 +429,6 @@ int main(int argc, char* argv[]) {
     bench.mark_prefill_start();
     auto output_ids = model.generate(input_ids, max_tokens, sampler_config, on_token);
     bench.mark_end();
-    double elapsed = timer.elapsed_ms();
     int gen_tokens = output_ids.size() - input_ids.size();
     NNOPT_CHECKPOINT("generation complete");
 
@@ -448,11 +445,6 @@ int main(int argc, char* argv[]) {
         }
         std::cout << std::endl;
     }
-
-    // Stats (human-readable summary — kept for backward compat with old parsers)
-    std::cerr << "Generated " << gen_tokens << " tokens in "
-              << elapsed << " ms ("
-              << (gen_tokens * 1000.0 / elapsed) << " tokens/sec)" << std::endl;
 
     // Structured baseline metrics for FinalizePort / README generation.
     bench.print_summary((int)input_ids.size(), gen_tokens);

--- a/src/models/lfm2-5-350m/src/main.cpp
+++ b/src/models/lfm2-5-350m/src/main.cpp
@@ -18,6 +18,8 @@
 #include <vector>
 #include <chrono>
 #include <fstream>
+#include <dlfcn.h>
+#include <CL/cl.h>
 
 // STREAM-style microbenchmark — measures the practical streaming-read
 // ceiling on this device for both buffer-cache and texture-cache reads.
@@ -135,6 +137,222 @@ static int run_bw_probe(OpenCLContext& cl_ctx) {
     return 0;
 }
 
+// cl_qcom_recordable_queues probe — proves we can record the per-token
+// decode dispatch sequence once and replay it cheaply, attacking the
+// ~16 ms/token host gap. Triggered via NNOPT_RECORD_PROBE=1; exits before
+// LLM work. Mirrors qwen2.5-0.5B/src/main.cpp:run_record_probe.
+//
+// On Razr 2020 / Adreno 620 (driver E031.37.12.07): bit 30
+// (CL_QUEUE_RECORDABLE_QCOM = 0x40000000) on clCreateCommandQueue, ALONE
+// (NOT combined with CL_QUEUE_PROFILING_ENABLE), creates a queue that
+// clNewRecordingQCOM accepts. The probe iterates many candidates so the
+// finding remains evidence-based on other devices.
+static int run_record_probe(OpenCLContext& cl_ctx) {
+    using namespace std::chrono;
+    cl_context  ctx = cl_ctx.context();
+    cl_command_queue q = cl_ctx.queue();
+    cl_int err = CL_SUCCESS;
+
+    typedef void* cl_recording_qcom;
+    typedef cl_recording_qcom (CL_API_CALL *clNewRecordingQCOM_fn)(
+        cl_command_queue, cl_int*);
+    typedef cl_int (CL_API_CALL *clEndRecordingQCOM_fn)(cl_recording_qcom);
+    typedef cl_int (CL_API_CALL *clReleaseRecordingQCOM_fn)(cl_recording_qcom);
+    struct cl_array_arg_qcom {
+        cl_kernel    kernel;
+        cl_uint      arg_indx;
+        size_t       arg_size;
+        const void*  arg_value;
+    };
+    struct cl_array_kernel_exec_info_qcom {
+        cl_kernel       kernel;
+        cl_uint         indx;
+        size_t          param_value_size;
+        const void*     param_value;
+    };
+    typedef cl_int (CL_API_CALL *clEnqueueRecordingQCOM_fn)(
+        cl_command_queue queue,
+        cl_recording_qcom recording,
+        size_t num_args,
+        const cl_array_arg_qcom* args,
+        size_t num_global_offsets,
+        const cl_array_kernel_exec_info_qcom* global_offsets,
+        size_t num_global_work_sizes,
+        const cl_array_kernel_exec_info_qcom* global_work_sizes,
+        size_t num_local_work_sizes,
+        const cl_array_kernel_exec_info_qcom* local_work_sizes,
+        cl_uint num_events_in_wait_list,
+        const cl_event* event_wait_list,
+        cl_event* event);
+
+    auto fnNew     = (clNewRecordingQCOM_fn)    dlsym(RTLD_DEFAULT, "clNewRecordingQCOM");
+    auto fnEnd     = (clEndRecordingQCOM_fn)    dlsym(RTLD_DEFAULT, "clEndRecordingQCOM");
+    auto fnRelease = (clReleaseRecordingQCOM_fn)dlsym(RTLD_DEFAULT, "clReleaseRecordingQCOM");
+    auto fnEnqueue = (clEnqueueRecordingQCOM_fn)dlsym(RTLD_DEFAULT, "clEnqueueRecordingQCOM");
+    if (!fnNew || !fnEnd || !fnRelease || !fnEnqueue) {
+        std::cerr << "Record: missing one or more entry points\n";
+        return 1;
+    }
+
+    cl_device_id dev = cl_ctx.device();
+    cl_command_queue probe_q = nullptr;
+    cl_recording_qcom winning_rec = nullptr;
+    int win_attempt = -1;
+    cl_command_queue live_q = q;
+
+    auto try_recording = [&](cl_command_queue qq, int attempt_id) -> bool {
+        cl_int e = 0;
+        cl_recording_qcom h = fnNew(qq, &e);
+        std::cerr << "  attempt " << attempt_id << ": clNewRecordingQCOM err="
+                  << e << " handle=" << h << "\n";
+        if (e == CL_SUCCESS && h) {
+            probe_q = qq;
+            fnEnd(h);
+            fnRelease(h);
+            win_attempt = attempt_id;
+            winning_rec = (cl_recording_qcom)1;
+            return true;
+        }
+        return false;
+    };
+
+    {
+        cl_command_queue_properties supp = 0;
+        clGetDeviceInfo(dev, CL_DEVICE_QUEUE_PROPERTIES, sizeof(supp), &supp, nullptr);
+        std::cerr << "  CL_DEVICE_QUEUE_PROPERTIES = 0x" << std::hex << supp << std::dec
+                  << " (bit 30=CL_QUEUE_RECORDABLE_QCOM)\n";
+    }
+
+    // Direct candidates per Snapdragon Programming Guide §9.1.3 — clCreateCommandQueue.
+    constexpr cl_command_queue_properties RECORD_BIT = (cl_command_queue_properties)1 << 30;
+    cl_command_queue_properties direct_candidates[] = {
+        RECORD_BIT,
+        RECORD_BIT | CL_QUEUE_PROFILING_ENABLE,
+        RECORD_BIT | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
+        RECORD_BIT | CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
+    };
+    for (size_t i = 0; i < sizeof(direct_candidates)/sizeof(direct_candidates[0]); ++i) {
+        if (winning_rec) break;
+        cl_int qerr = 0;
+        cl_command_queue qq = clCreateCommandQueue(ctx, dev, direct_candidates[i], &qerr);
+        std::cerr << "  direct: props=0x" << std::hex << direct_candidates[i] << std::dec
+                  << " qerr=" << qerr << " qq=" << qq << "\n";
+        if (qerr == CL_SUCCESS && qq) {
+            if (!try_recording(qq, 400 + (int)i)) clReleaseCommandQueue(qq);
+        }
+    }
+
+    if (!winning_rec) {
+        std::cerr << "Record: no candidate worked. Aborting.\n";
+        return 1;
+    }
+    std::cerr << "Record: WIN attempt " << win_attempt
+              << " (probe_q=" << probe_q << ")\n";
+
+    // Build the probe kernel from the gemv_m1.cl program.
+    std::ifstream f("kernels/gemv_m1.cl", std::ios::binary);
+    std::string src_text((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    cl_program prog = OpenCLContext::build_cached_program_from_queue(q, src_text, "");
+    if (!prog) { std::cerr << "build kernels fail\n"; return 1; }
+    cl_kernel k = clCreateKernel(prog, "probe_noop", &err);
+    if (err != CL_SUCCESS) { std::cerr << "createKernel fail " << err << "\n"; return 1; }
+
+    cl_mem counter = clCreateBuffer(ctx, CL_MEM_READ_WRITE, sizeof(cl_int), nullptr, &err);
+    if (err != CL_SUCCESS) { std::cerr << "alloc counter fail\n"; return 1; }
+    int incr = 1;
+    clSetKernelArg(k, 0, sizeof(cl_mem), &counter);
+    clSetKernelArg(k, 1, sizeof(int),    &incr);
+
+    constexpr int N_DISPATCH_PER_RECORDING = 100;
+    constexpr int N_REPLAYS                = 100;
+    constexpr int N_BASELINE_DISPATCHES    = N_DISPATCH_PER_RECORDING * N_REPLAYS;
+
+    auto reset_counter = [&]() {
+        cl_int zero = 0;
+        clEnqueueWriteBuffer(live_q, counter, CL_TRUE, 0, sizeof(int), &zero, 0, nullptr, nullptr);
+    };
+    auto read_counter = [&]() {
+        cl_int v = 0;
+        clEnqueueReadBuffer(live_q, counter, CL_TRUE, 0, sizeof(int), &v, 0, nullptr, nullptr);
+        return v;
+    };
+
+    // Baseline: N_BASELINE_DISPATCHES sequential clEnqueueNDRangeKernel on live_q.
+    reset_counter();
+    size_t gws = 1, lws = 1;
+    auto t0 = high_resolution_clock::now();
+    for (int i = 0; i < N_BASELINE_DISPATCHES; ++i) {
+        clEnqueueNDRangeKernel(live_q, k, 1, nullptr, &gws, &lws, 0, nullptr, nullptr);
+    }
+    clFinish(live_q);
+    auto t1 = high_resolution_clock::now();
+    double base_ms = duration<double, std::milli>(t1 - t0).count();
+    int base_val = read_counter();
+    std::cerr << "Baseline: " << N_BASELINE_DISPATCHES << " sequential dispatches → "
+              << base_ms << " ms, counter=" << base_val << "\n";
+
+    // Recording: capture N_DISPATCH_PER_RECORDING enqueues on probe_q.
+    reset_counter();
+    cl_int new_err = 0;
+    cl_recording_qcom rec = fnNew(probe_q, &new_err);
+    if (new_err != CL_SUCCESS || !rec) {
+        std::cerr << "Record: clNewRecordingQCOM failed err=" << new_err << "\n";
+        return 1;
+    }
+    for (int i = 0; i < N_DISPATCH_PER_RECORDING; ++i) {
+        cl_int e = clEnqueueNDRangeKernel(probe_q, k, 1, nullptr, &gws, &lws, 0, nullptr, nullptr);
+        if (e != CL_SUCCESS) {
+            std::cerr << "Record: enqueue during record failed at i=" << i << " err=" << e << "\n";
+            fnRelease(rec);
+            return 1;
+        }
+    }
+    cl_int end_err = fnEnd(rec);
+    if (end_err != CL_SUCCESS) {
+        std::cerr << "Record: end failed err=" << end_err << "\n";
+        fnRelease(rec);
+        return 1;
+    }
+
+    // Replay: N_REPLAYS × N_DISPATCH_PER_RECORDING dispatches on live_q.
+    reset_counter();
+    auto t2 = high_resolution_clock::now();
+    for (int r = 0; r < N_REPLAYS; ++r) {
+        cl_int e = fnEnqueue(live_q, rec,
+            0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr,
+            0, nullptr, nullptr);
+        if (e != CL_SUCCESS) {
+            std::cerr << "Record: replay failed at r=" << r << " err=" << e << "\n";
+            fnRelease(rec);
+            return 1;
+        }
+    }
+    clFinish(live_q);
+    auto t3 = high_resolution_clock::now();
+    double replay_ms = duration<double, std::milli>(t3 - t2).count();
+    int replay_val = read_counter();
+    std::cerr << "Replay: " << N_BASELINE_DISPATCHES << " dispatches → "
+              << replay_ms << " ms, counter=" << replay_val << "\n";
+
+    if (replay_val != base_val) {
+        std::cerr << "Record: COUNTER MISMATCH (replay isn't equivalent)\n";
+    } else {
+        double speedup = base_ms / replay_ms;
+        double per_baseline = base_ms / N_BASELINE_DISPATCHES * 1000.0;
+        double per_replay   = replay_ms / N_BASELINE_DISPATCHES * 1000.0;
+        std::cerr << "Record: speedup = " << speedup << "× ("
+                  << per_baseline << " µs/dispatch baseline → "
+                  << per_replay   << " µs/dispatch replay)\n";
+    }
+
+    fnRelease(rec);
+    clReleaseMemObject(counter);
+    clReleaseKernel(k);
+    clReleaseProgram(prog);
+    clReleaseCommandQueue(probe_q);
+    return 0;
+}
+
 static std::vector<int> load_token_ids_from_file(const std::string& path) {
     std::vector<int> ids;
     FILE* f = fopen(path.c_str(), "rb");
@@ -209,6 +427,10 @@ int main(int argc, char* argv[]) {
     // Bandwidth probe — exits before LLM work. Toggle with NNOPT_BW_PROBE=1.
     if (const char* bw = std::getenv("NNOPT_BW_PROBE"); bw && bw[0] == '1') {
         return run_bw_probe(cl_ctx);
+    }
+    // cl_qcom_recordable_queues probe — exits before LLM work. Toggle with NNOPT_RECORD_PROBE=1.
+    if (const char* rp = std::getenv("NNOPT_RECORD_PROBE"); rp && rp[0] == '1') {
+        return run_record_probe(cl_ctx);
     }
 
     // Load tokenizer (still needed for decoding output)

--- a/src/models/lfm2-5-350m/src/model.cpp
+++ b/src/models/lfm2-5-350m/src/model.cpp
@@ -358,6 +358,86 @@ int32_t Model::forward_greedy(const std::vector<int32_t>& input_ids, int start_p
   return result;
 }
 
+// Step 10: chained-decode forward. Mirrors forward_greedy at seq_len=1, but
+// (a) reads the input token from argmax_out_idx_ via embedding_->forward_from_device_token,
+// (b) skips the per-call sub-buffer (offset=0 at seq_len=1, so logits_buf_
+//     itself is the row), and (c) does NOT block on a host readback.
+// Caller pipelines an async readback of argmax_out_buffer().
+bool Model::forward_greedy_chained_enqueue(int start_pos) {
+  if (!ensure_argmax_resources_()) return false;
+
+  const int seq_len = 1;
+  cl_command_queue queue = cl_ctx_.queue();
+
+  cl_mem hidden = embedding_->forward_from_device_token(queue, argmax_out_idx_, /*offset=*/0);
+  if (!hidden) { NNOPT_ERROR("chained: embedding forward failed"); return false; }
+
+  for (int i = 0; i < MODEL_CONFIG::NUM_LAYERS; ++i) {
+    cl_mem op_norm = operator_norm_[i]->forward(queue, hidden, seq_len);
+    cl_mem op_out = nullptr;
+    if (layer_has_attention(i)) {
+      op_out = attn_[i]->forward(queue, op_norm, seq_len, start_pos);
+    } else if (layer_has_convolution(i)) {
+      op_out = conv_[i]->forward(queue, op_norm, seq_len, start_pos);
+    } else {
+      NNOPT_ERROR_FMT("chained: layer %d has no op", i);
+      return false;
+    }
+    if (!op_out) { NNOPT_ERROR_FMT("chained: op forward null at layer %d", i); return false; }
+
+    element_add_inplace(queue, utils_program_, hidden, op_out, (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
+
+    cl_mem ffn_norm = ffn_norm_[i]->forward(queue, hidden, seq_len);
+    cl_mem mlp_out = mlp_[i]->forward(queue, ffn_norm, seq_len);
+    if (!mlp_out) { NNOPT_ERROR_FMT("chained: mlp null at layer %d", i); return false; }
+
+    element_add_inplace(queue, utils_program_, hidden, mlp_out, (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
+  }
+
+  hidden = embedding_norm_->forward(queue, hidden, seq_len);
+  if (!hidden) { NNOPT_ERROR("chained: embedding_norm failed"); return false; }
+
+  cl_mem W = weights_.get_buffer("model.embed_tokens.weight");
+  if (!W) return false;
+  cl_mem logits_buf = ensure_logits_buf(cl_ctx_.context(), buf_logits_, buf_logits_seq_capacity_, seq_len);
+  if (!logits_buf) return false;
+
+  if (!pytorch_linear(queue, seq_len, MODEL_CONFIG::VOCAB_SIZE, MODEL_CONFIG::HIDDEN_SIZE,
+                      hidden, W, logits_buf)) {
+    return false;
+  }
+
+  // At seq_len=1, the (only) row begins at offset 0, so logits_buf is itself
+  // the "last row" — no sub-buffer needed.
+  const int V = MODEL_CONFIG::VOCAB_SIZE;
+  const int CHUNK = 1024;
+  const int num_wg = (V + CHUNK - 1) / CHUNK;
+
+  cl_int err = clSetKernelArg(argmax_block_kernel_, 0, sizeof(cl_mem), &logits_buf);
+  err |= clSetKernelArg(argmax_block_kernel_, 1, sizeof(cl_mem), &argmax_partials_val_);
+  err |= clSetKernelArg(argmax_block_kernel_, 2, sizeof(cl_mem), &argmax_partials_idx_);
+  err |= clSetKernelArg(argmax_block_kernel_, 3, sizeof(int),    &V);
+  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("chained: argmax_block setArgs: %d", err); return false; }
+  size_t gws_b = (size_t)num_wg * 64;
+  size_t lws_b = 64;
+  err = clEnqueueNDRangeKernel(queue, argmax_block_kernel_, 1, nullptr, &gws_b, &lws_b, 0, nullptr,
+                               KernelProfiler::event_for("argmax_block_chained"));
+  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("chained: argmax_block dispatch: %d", err); return false; }
+
+  err = clSetKernelArg(argmax_final_kernel_, 0, sizeof(cl_mem), &argmax_partials_val_);
+  err |= clSetKernelArg(argmax_final_kernel_, 1, sizeof(cl_mem), &argmax_partials_idx_);
+  err |= clSetKernelArg(argmax_final_kernel_, 2, sizeof(cl_mem), &argmax_out_idx_);
+  err |= clSetKernelArg(argmax_final_kernel_, 3, sizeof(int),    &num_wg);
+  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("chained: argmax_final setArgs: %d", err); return false; }
+  size_t gws_f = 64;
+  size_t lws_f = 64;
+  err = clEnqueueNDRangeKernel(queue, argmax_final_kernel_, 1, nullptr, &gws_f, &lws_f, 0, nullptr,
+                               KernelProfiler::event_for("argmax_final_chained"));
+  if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("chained: argmax_final dispatch: %d", err); return false; }
+
+  return true;
+}
+
 std::vector<int32_t> Model::generate(const std::vector<int32_t>& prompt_ids, int max_new_tokens, SamplerConfig sampler_config, TokenCallback on_token) {
   NNOPT_CHECKPOINT("generate() started");
   Sampler sampler(sampler_config);
@@ -393,6 +473,73 @@ std::vector<int32_t> Model::generate(const std::vector<int32_t>& prompt_ids, int
     return ids;
   }
 
+  // Step 10 fast path: pipelined chained decode. Embedding reads its single
+  // input token directly from argmax_out_idx_ (written by the previous
+  // forward); the host readback runs asynchronously and we wait on it one
+  // iteration LATER, so the readback latency is hidden behind the next
+  // forward's enqueue. After prefill, argmax_out_idx_ already holds the
+  // first generated token, so iteration i=1 generates the second token.
+  if (greedy_fast && max_new_tokens > 1) {
+    cl_command_queue queue = cl_ctx_.queue();
+    int32_t host_int[2] = {0, 0};
+    cl_event readback_event[2] = {nullptr, nullptr};
+    bool slot_pending[2] = {false, false};
+    int prev_slot = -1;
+    bool eos_seen = false;
+
+    for (int i = 1; i < max_new_tokens && !eos_seen; i++) {
+      const int pos = (int)prompt_ids.size() + (i - 1);
+      const int cur_slot = i & 1;
+
+      if (!forward_greedy_chained_enqueue(pos)) {
+        NNOPT_ERROR("chained decode forward failed");
+        break;
+      }
+
+      cl_int rerr = clEnqueueReadBuffer(queue, argmax_out_idx_, CL_FALSE, 0,
+                                        sizeof(int32_t), &host_int[cur_slot],
+                                        0, nullptr, &readback_event[cur_slot]);
+      if (rerr != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("chained async readback enqueue failed (%d)", (int)rerr);
+        break;
+      }
+      slot_pending[cur_slot] = true;
+      clFlush(queue);
+
+      if (prev_slot >= 0 && slot_pending[prev_slot]) {
+        clWaitForEvents(1, &readback_event[prev_slot]);
+        clReleaseEvent(readback_event[prev_slot]);
+        readback_event[prev_slot] = nullptr;
+        slot_pending[prev_slot] = false;
+        int32_t t = host_int[prev_slot];
+        ids.push_back(t);
+        generated.push_back(t);
+        if (on_token) on_token(t, ids);
+        if (sampler_config.eos_token_id >= 0 && t == sampler_config.eos_token_id) {
+          eos_seen = true;
+        }
+      }
+      prev_slot = cur_slot;
+    }
+
+    if (prev_slot >= 0 && slot_pending[prev_slot]) {
+      clWaitForEvents(1, &readback_event[prev_slot]);
+      clReleaseEvent(readback_event[prev_slot]);
+      readback_event[prev_slot] = nullptr;
+      slot_pending[prev_slot] = false;
+      if (!eos_seen) {
+        int32_t t = host_int[prev_slot];
+        ids.push_back(t);
+        generated.push_back(t);
+        if (on_token) on_token(t, ids);
+      }
+    }
+
+    NNOPT_CHECKPOINT("generate() complete (chained)");
+    return ids;
+  }
+
+  // Non-greedy or 1-token decode: original blocking loop.
   for (int i = 1; i < max_new_tokens; i++) {
     const int pos = (int)prompt_ids.size() + (i - 1);
     if (greedy_fast) {

--- a/src/models/lfm2-5-350m/src/model.h
+++ b/src/models/lfm2-5-350m/src/model.h
@@ -44,6 +44,15 @@ public:
     // (temperature<=0 AND repetition_penalty==1).
     int32_t forward_greedy(const std::vector<int32_t>& input_ids, int start_pos);
 
+    // Step 10: chained-decode forward (single token). Embedding reads its
+    // input token from `argmax_out_idx_` (written by the previous forward),
+    // and the final argmax writes back into `argmax_out_idx_`. NO host
+    // readback inside this function — caller is responsible for pipelining
+    // a CL_FALSE clEnqueueReadBuffer of argmax_out_buffer() and waiting on
+    // the event when needed (e.g. for streaming/EOS check).
+    bool forward_greedy_chained_enqueue(int start_pos);
+    cl_mem argmax_out_buffer() const { return argmax_out_idx_; }
+
     std::vector<int32_t> generate(
         const std::vector<int32_t>& prompt_ids,
         int max_new_tokens = 64,

--- a/src/models/lfm2-5-350m/src/opencl_context.cpp
+++ b/src/models/lfm2-5-350m/src/opencl_context.cpp
@@ -8,6 +8,9 @@
 #include <cstdint>
 #include <sys/stat.h>
 #include <dlfcn.h>
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#endif
 
 // ──────────────────────────────────────────────────────────────────────
 // Program binary cache — fixes the cold-start TTFT problem (~30 s
@@ -345,4 +348,101 @@ size_t OpenCLContext::local_mem_size() const {
     cl_ulong size;
     clGetDeviceInfo(device_, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(size), &size, nullptr);
     return (size_t)size;
+}
+
+std::string OpenCLContext::device_description() const {
+    auto str = [&](cl_device_info q) -> std::string {
+        char buf[512] = {0};
+        if (clGetDeviceInfo(device_, q, sizeof(buf), buf, nullptr) != CL_SUCCESS) return "?";
+        return std::string(buf);
+    };
+    auto u32 = [&](cl_device_info q) -> std::string {
+        cl_uint v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return "?";
+        return std::to_string(v);
+    };
+    auto u64_bytes = [&](cl_device_info q) -> cl_ulong {
+        cl_ulong v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return 0;
+        return v;
+    };
+
+    // Adreno's KGSL driver exposes the actual GPU model at /sys/class/kgsl/...
+    // Older driver builds return only "QUALCOMM Adreno(TM)" via CL_DEVICE_NAME
+    // (no chip number); splice the sysfs model in when CL_DEVICE_NAME lacks digits.
+    std::string name = device_name();
+    bool name_has_digit = false;
+    for (char c : name) if (c >= '0' && c <= '9') { name_has_digit = true; break; }
+    if (!name_has_digit) {
+        std::ifstream f("/sys/class/kgsl/kgsl-3d0/gpu_model");
+        std::string m;
+        if (f.is_open() && std::getline(f, m)) {
+            while (!m.empty() && (m.back() == '\n' || m.back() == '\r' || m.back() == ' ')) m.pop_back();
+            // "Adreno620v2" -> "Adreno 620v2"
+            size_t apos = m.find("Adreno");
+            if (apos != std::string::npos && apos + 6 < m.size() &&
+                m[apos + 6] >= '0' && m[apos + 6] <= '9') {
+                m.insert(apos + 6, " ");
+            }
+            const std::string tm_marker = "Adreno(TM)";
+            size_t tm = name.find(tm_marker);
+            if (!m.empty() && tm != std::string::npos) {
+                name.replace(tm, tm_marker.size(), m);
+            } else if (!m.empty()) {
+                name += " (" + m + ")";
+            }
+        }
+    }
+
+    // CL_DEVICE_VERSION is "OpenCL X.Y <impl details>" — keep just "X.Y".
+    std::string ver = str(CL_DEVICE_VERSION);
+    if (ver.rfind("OpenCL ", 0) == 0) {
+        size_t sp = ver.find(' ', 7);
+        ver = (sp == std::string::npos) ? ver.substr(7) : ver.substr(7, sp - 7);
+    }
+
+    // CL_DRIVER_VERSION on Adreno is a verbose build banner. The only piece
+    // that meaningfully changes between driver releases is the "Compiler EXXX..."
+    // token — extract it; fall back to first whitespace-token otherwise.
+    std::string drv = str(CL_DRIVER_VERSION);
+    {
+        size_t pos = drv.find("Compiler ");
+        if (pos != std::string::npos) drv = drv.substr(pos + 9);
+        size_t end = drv.find_first_of(" \t\r\n");
+        if (end != std::string::npos) drv = drv.substr(0, end);
+    }
+
+    cl_ulong gmem = u64_bytes(CL_DEVICE_GLOBAL_MEM_SIZE);
+    cl_ulong lmem = u64_bytes(CL_DEVICE_LOCAL_MEM_SIZE);
+    char gbuf[32], lbuf[32];
+    snprintf(gbuf, sizeof(gbuf), "%.1f GB", gmem / 1e9);
+    snprintf(lbuf, sizeof(lbuf), "%llu KB", (unsigned long long)(lmem / 1024));
+
+    // Android SoC model + platform codename. OpenCL exposes neither, so this
+    // is the only way to surface the actual chip (e.g. SM7250 / lito).
+    std::string soc;
+#ifdef __ANDROID__
+    {
+        char model[PROP_VALUE_MAX] = {0};
+        char board[PROP_VALUE_MAX] = {0};
+        __system_property_get("ro.soc.model", model);
+        __system_property_get("ro.board.platform", board);
+        if (model[0]) {
+            soc = model;
+            if (board[0]) soc += " (" + std::string(board) + ")";
+        } else if (board[0]) {
+            soc = board;
+        }
+    }
+#endif
+
+    std::ostringstream os;
+    os << name << "\n";
+    if (!soc.empty()) os << "  SoC:    " << soc << "\n";
+    os << "  Memory: " << gbuf << " global / " << lbuf << " local\n"
+       << "  CUs:    " << u32(CL_DEVICE_MAX_COMPUTE_UNITS) << "\n"
+       << "  Clock:  " << u32(CL_DEVICE_MAX_CLOCK_FREQUENCY) << " MHz\n"
+       << "  OpenCL: " << ver << "\n"
+       << "  Driver: " << drv;
+    return os.str();
 }

--- a/src/models/lfm2-5-350m/src/opencl_context.h
+++ b/src/models/lfm2-5-350m/src/opencl_context.h
@@ -23,6 +23,7 @@ public:
 
     // Device info
     std::string device_name() const;
+    std::string device_description() const;
     size_t max_work_group_size() const;
     size_t local_mem_size() const;
 

--- a/src/models/lfm2-5-350m/src/utils.cpp
+++ b/src/models/lfm2-5-350m/src/utils.cpp
@@ -155,8 +155,10 @@ static cl_kernel  s_gemv_m1_k1024      = nullptr;
 static cl_kernel  s_gemv_m1_k1024_no4  = nullptr;
 static cl_kernel  s_gemv_m1_k4608_no4  = nullptr;
 // Image-backed variants (Adreno texture L1 cache, 1.71× faster than buffer L2 on Razr 2020).
+static cl_kernel  s_gemv_m1_k1024_no8_img = nullptr;
 static cl_kernel  s_gemv_m1_k1024_no4_img = nullptr;
 static cl_kernel  s_gemv_m1_k1024_no2_img = nullptr;
+static cl_kernel  s_gemv_m1_k1024_no8_silufused_img = nullptr;
 static cl_kernel  s_gemv_m1_k4608_no4_img = nullptr;
 
 // Per-buffer image2d_t view cache (lazy). Standard entries hold one image;
@@ -217,6 +219,8 @@ static bool ensure_gemv_m1_program(cl_command_queue queue) {
     s_gemv_m1_k4608_no4 = clCreateKernel(s_gemv_m1_prog, "gemv_m1_k4608_no4", &err);
     if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("gemv_m1: k4608_no4 create failed (%d)", err); }
     // Image variants — optional (silently null on devices without image2d-from-buffer).
+    s_gemv_m1_k1024_no8_img = clCreateKernel(s_gemv_m1_prog, "gemv_m1_k1024_no8_img", &err);
+    if (err != CL_SUCCESS) { s_gemv_m1_k1024_no8_img = nullptr; }
     s_gemv_m1_k1024_no4_img = clCreateKernel(s_gemv_m1_prog, "gemv_m1_k1024_no4_img", &err);
     if (err != CL_SUCCESS) { s_gemv_m1_k1024_no4_img = nullptr; }
     s_gemv_m1_k1024_no2_img = clCreateKernel(s_gemv_m1_prog, "gemv_m1_k1024_no2_img", &err);
@@ -224,6 +228,52 @@ static bool ensure_gemv_m1_program(cl_command_queue queue) {
     s_gemv_m1_k4608_no4_img = clCreateKernel(s_gemv_m1_prog, "gemv_m1_k4608_no4_img", &err);
     if (err != CL_SUCCESS) { s_gemv_m1_k4608_no4_img = nullptr; }
     return s_gemv_m1_k1024 && s_gemv_m1_k4608_no4;
+}
+
+// Separate cl_program for the silufused kernel — keeping it in gemv_m1.cl
+// caused Adreno's compiler to spill registers in the no8_img kernels,
+// regressing decode by ~10×. Compiling as standalone isolates allocation.
+static cl_program s_mlp_fused_prog = nullptr;
+
+static bool ensure_mlp_fused_program(cl_command_queue queue) {
+    if (s_mlp_fused_prog) return true;
+
+    cl_context   ctx    = nullptr;
+    cl_device_id device = nullptr;
+    clGetCommandQueueInfo(queue, CL_QUEUE_CONTEXT, sizeof(ctx),    &ctx,    nullptr);
+    clGetCommandQueueInfo(queue, CL_QUEUE_DEVICE,  sizeof(device), &device, nullptr);
+    if (!ctx || !device) return false;
+
+    std::ifstream f("kernels/mlp_fused.cl", std::ios::binary);
+    if (!f.is_open()) {
+        NNOPT_ERROR_FMT("mlp_fused: cannot open kernels/mlp_fused.cl%s", "");
+        return false;
+    }
+    std::string src((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    const char* src_cstr = src.c_str();
+    size_t src_len = src.size();
+    cl_int err;
+    s_mlp_fused_prog = clCreateProgramWithSource(ctx, 1, &src_cstr, &src_len, &err);
+    if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("mlp_fused: clCreateProgramWithSource failed (%d)", (int)err);
+        return false;
+    }
+    err = clBuildProgram(s_mlp_fused_prog, 1, &device, "-cl-fast-relaxed-math", nullptr, nullptr);
+    if (err != CL_SUCCESS) {
+        size_t log_size = 0;
+        clGetProgramBuildInfo(s_mlp_fused_prog, device, CL_PROGRAM_BUILD_LOG, 0, nullptr, &log_size);
+        if (log_size > 0) {
+            std::vector<char> log(log_size + 1, 0);
+            clGetProgramBuildInfo(s_mlp_fused_prog, device, CL_PROGRAM_BUILD_LOG, log_size, log.data(), nullptr);
+            fprintf(stderr, "mlp_fused build log: %s\n", log.data());
+        }
+        clReleaseProgram(s_mlp_fused_prog);
+        s_mlp_fused_prog = nullptr;
+        return false;
+    }
+    s_gemv_m1_k1024_no8_silufused_img = clCreateKernel(s_mlp_fused_prog, "gemv_m1_k1024_no8_silufused_img", &err);
+    if (err != CL_SUCCESS) { s_gemv_m1_k1024_no8_silufused_img = nullptr; }
+    return s_gemv_m1_k1024_no8_silufused_img != nullptr;
 }
 
 // Look up (or create on first use) an image2d_t view of fp16 weight buffer W
@@ -309,7 +359,14 @@ static bool run_gemv_m1_image(cl_command_queue queue, int N, int K, cl_mem W, cl
     if (!ensure_gemv_m1_program(queue)) return false;
     cl_kernel k = nullptr;
     int stride = 4;  // outputs per WG
-    if (K == 1024 && (N % 4) == 0 && s_gemv_m1_k1024_no4_img) {
+    // no8 wins for large N (more arithmetic density per thread hides texture
+    // latency better) but loses for small N where the thread count drops
+    // below the device's latency-hiding threshold. Profile (Adreno 620):
+    //   N=4608/3072/65536-tile-16384: +10-19% with no8
+    //   N=1024: -2%, N=512: -11% (fall back to no4).
+    if (K == 1024 && N >= 2048 && (N % 8) == 0 && s_gemv_m1_k1024_no8_img) {
+        k = s_gemv_m1_k1024_no8_img; stride = 8;
+    } else if (K == 1024 && (N % 4) == 0 && s_gemv_m1_k1024_no4_img) {
         k = s_gemv_m1_k1024_no4_img; stride = 4;
     } else if (K == 1024 && (N % 2) == 0 && s_gemv_m1_k1024_no2_img) {
         k = s_gemv_m1_k1024_no2_img; stride = 2;
@@ -793,6 +850,43 @@ bool pytorch_linear(cl_command_queue queue,
     NNOPT_DEBUG_SYNC(queue);
     return true;
 }
+
+#ifdef NNOPT_USE_FP16
+bool pytorch_linear_silu_gate_fused(cl_command_queue queue,
+                                    int N, int K,
+                                    cl_mem x, cl_mem W3, cl_mem gate_inout) {
+    // Eligibility: K=1024, N%8==0, no8 silufused kernel built, image2d view of W3 available.
+    if (K != 1024 || (N % 8) != 0) return false;
+    if (!ensure_gemv_m1_program(queue)) return false;
+    if (!ensure_mlp_fused_program(queue)) return false;
+    if (!s_gemv_m1_k1024_no8_silufused_img) return false;
+
+    const WImageEntry* ent = get_or_create_w_image(queue, W3, N, K);
+    if (!ent || !ent->image) return false;  // tiled path not supported here (lm_head only)
+
+    cl_kernel k = s_gemv_m1_k1024_no8_silufused_img;
+    clSetKernelArg(k, 0, sizeof(cl_mem), &x);
+    clSetKernelArg(k, 1, sizeof(cl_mem), &ent->image);
+    clSetKernelArg(k, 2, sizeof(cl_mem), &gate_inout);
+    clSetKernelArg(k, 3, sizeof(int),    &N);
+
+    const size_t WG = 64;
+    size_t gws = (size_t)(N / 8) * WG;
+    size_t lws = WG;
+    cl_event* evt = KernelProfiler::event_for("gemv_m1_K1024_no8_silufused_img");
+    cl_int err = clEnqueueNDRangeKernel(queue, k, 1, nullptr, &gws, &lws, 0, nullptr, evt);
+    if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("silufused enqueue: %d (N=%d)", err, N);
+        return false;
+    }
+    NNOPT_DEBUG_SYNC(queue);
+    return true;
+}
+#else
+bool pytorch_linear_silu_gate_fused(cl_command_queue, int, int, cl_mem, cl_mem, cl_mem) {
+    return false;  // fp32 build: no image path, fall back to host
+}
+#endif
 
 bool pytorch_conv1d(cl_command_queue queue,
                     int M, int N, int K,

--- a/src/models/lfm2-5-350m/src/utils.h
+++ b/src/models/lfm2-5-350m/src/utils.h
@@ -118,6 +118,16 @@ bool pytorch_linear(cl_command_queue queue,
                     int M, int N, int K,
                     cl_mem x, cl_mem W, cl_mem out);
 
+// MLP w3 + silu_mul fused into one kernel. Reads gate_inout[n] (= w1·x
+// from a prior pytorch_linear call), reads W3 via image2d, computes
+// silu(gate_inout[n]) * (W3·x), and writes the result back into
+// gate_inout. Eliminates the separate silu_mul kernel + the buf_up_
+// intermediate buffer for SwiGLU MLPs. M=1 only; falls back to false
+// if K=1024 image path or no8 kernel are unavailable.
+bool pytorch_linear_silu_gate_fused(cl_command_queue queue,
+                                    int N, int K,
+                                    cl_mem x, cl_mem W3, cl_mem gate_inout);
+
 // ──────────────────────────────────────────────
 // pytorch_conv1d: dtype-templated GEMM wrapper for HF Conv1D layout
 // ──────────────────────────────────────────────

--- a/src/models/mamba-130m/src/main.cpp
+++ b/src/models/mamba-130m/src/main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed to initialize OpenCL" << std::endl;
         return 1;
     }
-    std::cerr << "Device: " << cl_ctx.device_name() << std::endl;
+    std::cerr << "Device: " << cl_ctx.device_description() << std::endl;
     NNOPT_CHECKPOINT("OpenCL initialized");
 
     // Load tokenizer (still needed for decoding output)
@@ -262,8 +262,6 @@ int main(int argc, char* argv[]) {
 
     // Generate
     NNOPT_CHECKPOINT("starting generation");
-    Timer timer;
-    timer.start();
 
     // Prefill clock starts now — excludes tokenize (see comment block above the
     // mark_inference_start() call for the full metric contract).
@@ -300,7 +298,6 @@ int main(int argc, char* argv[]) {
         std::fflush(stdout);
     }
     bench.mark_end();
-    double elapsed = timer.elapsed_ms();
     int gen_tokens = output_ids.size() - input_ids.size();
     NNOPT_CHECKPOINT("generation complete");
 
@@ -329,11 +326,6 @@ int main(int argc, char* argv[]) {
         }
         std::cout << std::endl;
     }
-
-    // Stats (human-readable summary — kept for backward compat with old parsers)
-    std::cerr << "Generated " << gen_tokens << " tokens in "
-              << elapsed << " ms ("
-              << (gen_tokens * 1000.0 / elapsed) << " tokens/sec)" << std::endl;
 
     // Structured baseline metrics for FinalizePort / README generation.
     bench.print_summary((int)input_ids.size(), gen_tokens);

--- a/src/models/mamba-130m/src/opencl_context.cpp
+++ b/src/models/mamba-130m/src/opencl_context.cpp
@@ -8,6 +8,9 @@
 #include <cstdint>
 #include <sys/stat.h>
 #include <dlfcn.h>
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#endif
 
 // ──────────────────────────────────────────────────────────────────────
 // Program binary cache — fixes the cold-start TTFT problem (~30 s
@@ -354,4 +357,101 @@ size_t OpenCLContext::local_mem_size() const {
     cl_ulong size;
     clGetDeviceInfo(device_, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(size), &size, nullptr);
     return (size_t)size;
+}
+
+std::string OpenCLContext::device_description() const {
+    auto str = [&](cl_device_info q) -> std::string {
+        char buf[512] = {0};
+        if (clGetDeviceInfo(device_, q, sizeof(buf), buf, nullptr) != CL_SUCCESS) return "?";
+        return std::string(buf);
+    };
+    auto u32 = [&](cl_device_info q) -> std::string {
+        cl_uint v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return "?";
+        return std::to_string(v);
+    };
+    auto u64_bytes = [&](cl_device_info q) -> cl_ulong {
+        cl_ulong v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return 0;
+        return v;
+    };
+
+    // Adreno's KGSL driver exposes the actual GPU model at /sys/class/kgsl/...
+    // Older driver builds return only "QUALCOMM Adreno(TM)" via CL_DEVICE_NAME
+    // (no chip number); splice the sysfs model in when CL_DEVICE_NAME lacks digits.
+    std::string name = device_name();
+    bool name_has_digit = false;
+    for (char c : name) if (c >= '0' && c <= '9') { name_has_digit = true; break; }
+    if (!name_has_digit) {
+        std::ifstream f("/sys/class/kgsl/kgsl-3d0/gpu_model");
+        std::string m;
+        if (f.is_open() && std::getline(f, m)) {
+            while (!m.empty() && (m.back() == '\n' || m.back() == '\r' || m.back() == ' ')) m.pop_back();
+            // "Adreno620v2" -> "Adreno 620v2"
+            size_t apos = m.find("Adreno");
+            if (apos != std::string::npos && apos + 6 < m.size() &&
+                m[apos + 6] >= '0' && m[apos + 6] <= '9') {
+                m.insert(apos + 6, " ");
+            }
+            const std::string tm_marker = "Adreno(TM)";
+            size_t tm = name.find(tm_marker);
+            if (!m.empty() && tm != std::string::npos) {
+                name.replace(tm, tm_marker.size(), m);
+            } else if (!m.empty()) {
+                name += " (" + m + ")";
+            }
+        }
+    }
+
+    // CL_DEVICE_VERSION is "OpenCL X.Y <impl details>" — keep just "X.Y".
+    std::string ver = str(CL_DEVICE_VERSION);
+    if (ver.rfind("OpenCL ", 0) == 0) {
+        size_t sp = ver.find(' ', 7);
+        ver = (sp == std::string::npos) ? ver.substr(7) : ver.substr(7, sp - 7);
+    }
+
+    // CL_DRIVER_VERSION on Adreno is a verbose build banner. The only piece
+    // that meaningfully changes between driver releases is the "Compiler EXXX..."
+    // token — extract it; fall back to first whitespace-token otherwise.
+    std::string drv = str(CL_DRIVER_VERSION);
+    {
+        size_t pos = drv.find("Compiler ");
+        if (pos != std::string::npos) drv = drv.substr(pos + 9);
+        size_t end = drv.find_first_of(" \t\r\n");
+        if (end != std::string::npos) drv = drv.substr(0, end);
+    }
+
+    cl_ulong gmem = u64_bytes(CL_DEVICE_GLOBAL_MEM_SIZE);
+    cl_ulong lmem = u64_bytes(CL_DEVICE_LOCAL_MEM_SIZE);
+    char gbuf[32], lbuf[32];
+    snprintf(gbuf, sizeof(gbuf), "%.1f GB", gmem / 1e9);
+    snprintf(lbuf, sizeof(lbuf), "%llu KB", (unsigned long long)(lmem / 1024));
+
+    // Android SoC model + platform codename. OpenCL exposes neither, so this
+    // is the only way to surface the actual chip (e.g. SM7250 / lito).
+    std::string soc;
+#ifdef __ANDROID__
+    {
+        char model[PROP_VALUE_MAX] = {0};
+        char board[PROP_VALUE_MAX] = {0};
+        __system_property_get("ro.soc.model", model);
+        __system_property_get("ro.board.platform", board);
+        if (model[0]) {
+            soc = model;
+            if (board[0]) soc += " (" + std::string(board) + ")";
+        } else if (board[0]) {
+            soc = board;
+        }
+    }
+#endif
+
+    std::ostringstream os;
+    os << name << "\n";
+    if (!soc.empty()) os << "  SoC:    " << soc << "\n";
+    os << "  Memory: " << gbuf << " global / " << lbuf << " local\n"
+       << "  CUs:    " << u32(CL_DEVICE_MAX_COMPUTE_UNITS) << "\n"
+       << "  Clock:  " << u32(CL_DEVICE_MAX_CLOCK_FREQUENCY) << " MHz\n"
+       << "  OpenCL: " << ver << "\n"
+       << "  Driver: " << drv;
+    return os.str();
 }

--- a/src/models/mamba-130m/src/opencl_context.h
+++ b/src/models/mamba-130m/src/opencl_context.h
@@ -26,6 +26,7 @@ public:
 
     // Device info
     std::string device_name() const;
+    std::string device_description() const;
     size_t max_work_group_size() const;
     size_t local_mem_size() const;
 

--- a/src/models/mamba2-130m/src/main.cpp
+++ b/src/models/mamba2-130m/src/main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed to initialize OpenCL" << std::endl;
         return 1;
     }
-    std::cerr << "Device: " << cl_ctx.device_name() << std::endl;
+    std::cerr << "Device: " << cl_ctx.device_description() << std::endl;
     NNOPT_CHECKPOINT("OpenCL initialized");
 
     // Load tokenizer (still needed for decoding output)
@@ -269,8 +269,6 @@ int main(int argc, char* argv[]) {
 
     // Generate
     NNOPT_CHECKPOINT("starting generation");
-    Timer timer;
-    timer.start();
 
     // Prefill clock starts now — excludes tokenize (see comment block above the
     // mark_inference_start() call for the full metric contract).
@@ -310,7 +308,6 @@ int main(int argc, char* argv[]) {
         std::fflush(stdout);
     }
     bench.mark_end();
-    double elapsed = timer.elapsed_ms();
     int gen_tokens = output_ids.size() - input_ids.size();
     NNOPT_CHECKPOINT("generation complete");
 
@@ -339,11 +336,6 @@ int main(int argc, char* argv[]) {
         }
         std::cout << std::endl;
     }
-
-    // Stats (human-readable summary — kept for backward compat with old parsers)
-    std::cerr << "Generated " << gen_tokens << " tokens in "
-              << elapsed << " ms ("
-              << (gen_tokens * 1000.0 / elapsed) << " tokens/sec)" << std::endl;
 
     // Structured baseline metrics for FinalizePort / README generation.
     bench.print_summary((int)input_ids.size(), gen_tokens);

--- a/src/models/mamba2-130m/src/opencl_context.cpp
+++ b/src/models/mamba2-130m/src/opencl_context.cpp
@@ -8,6 +8,9 @@
 #include <cstdint>
 #include <sys/stat.h>
 #include <dlfcn.h>
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#endif
 
 // ──────────────────────────────────────────────────────────────────────
 // Program binary cache — fixes the cold-start TTFT problem (~30 s
@@ -345,4 +348,101 @@ size_t OpenCLContext::local_mem_size() const {
     cl_ulong size;
     clGetDeviceInfo(device_, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(size), &size, nullptr);
     return (size_t)size;
+}
+
+std::string OpenCLContext::device_description() const {
+    auto str = [&](cl_device_info q) -> std::string {
+        char buf[512] = {0};
+        if (clGetDeviceInfo(device_, q, sizeof(buf), buf, nullptr) != CL_SUCCESS) return "?";
+        return std::string(buf);
+    };
+    auto u32 = [&](cl_device_info q) -> std::string {
+        cl_uint v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return "?";
+        return std::to_string(v);
+    };
+    auto u64_bytes = [&](cl_device_info q) -> cl_ulong {
+        cl_ulong v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return 0;
+        return v;
+    };
+
+    // Adreno's KGSL driver exposes the actual GPU model at /sys/class/kgsl/...
+    // Older driver builds return only "QUALCOMM Adreno(TM)" via CL_DEVICE_NAME
+    // (no chip number); splice the sysfs model in when CL_DEVICE_NAME lacks digits.
+    std::string name = device_name();
+    bool name_has_digit = false;
+    for (char c : name) if (c >= '0' && c <= '9') { name_has_digit = true; break; }
+    if (!name_has_digit) {
+        std::ifstream f("/sys/class/kgsl/kgsl-3d0/gpu_model");
+        std::string m;
+        if (f.is_open() && std::getline(f, m)) {
+            while (!m.empty() && (m.back() == '\n' || m.back() == '\r' || m.back() == ' ')) m.pop_back();
+            // "Adreno620v2" -> "Adreno 620v2"
+            size_t apos = m.find("Adreno");
+            if (apos != std::string::npos && apos + 6 < m.size() &&
+                m[apos + 6] >= '0' && m[apos + 6] <= '9') {
+                m.insert(apos + 6, " ");
+            }
+            const std::string tm_marker = "Adreno(TM)";
+            size_t tm = name.find(tm_marker);
+            if (!m.empty() && tm != std::string::npos) {
+                name.replace(tm, tm_marker.size(), m);
+            } else if (!m.empty()) {
+                name += " (" + m + ")";
+            }
+        }
+    }
+
+    // CL_DEVICE_VERSION is "OpenCL X.Y <impl details>" — keep just "X.Y".
+    std::string ver = str(CL_DEVICE_VERSION);
+    if (ver.rfind("OpenCL ", 0) == 0) {
+        size_t sp = ver.find(' ', 7);
+        ver = (sp == std::string::npos) ? ver.substr(7) : ver.substr(7, sp - 7);
+    }
+
+    // CL_DRIVER_VERSION on Adreno is a verbose build banner. The only piece
+    // that meaningfully changes between driver releases is the "Compiler EXXX..."
+    // token — extract it; fall back to first whitespace-token otherwise.
+    std::string drv = str(CL_DRIVER_VERSION);
+    {
+        size_t pos = drv.find("Compiler ");
+        if (pos != std::string::npos) drv = drv.substr(pos + 9);
+        size_t end = drv.find_first_of(" \t\r\n");
+        if (end != std::string::npos) drv = drv.substr(0, end);
+    }
+
+    cl_ulong gmem = u64_bytes(CL_DEVICE_GLOBAL_MEM_SIZE);
+    cl_ulong lmem = u64_bytes(CL_DEVICE_LOCAL_MEM_SIZE);
+    char gbuf[32], lbuf[32];
+    snprintf(gbuf, sizeof(gbuf), "%.1f GB", gmem / 1e9);
+    snprintf(lbuf, sizeof(lbuf), "%llu KB", (unsigned long long)(lmem / 1024));
+
+    // Android SoC model + platform codename. OpenCL exposes neither, so this
+    // is the only way to surface the actual chip (e.g. SM7250 / lito).
+    std::string soc;
+#ifdef __ANDROID__
+    {
+        char model[PROP_VALUE_MAX] = {0};
+        char board[PROP_VALUE_MAX] = {0};
+        __system_property_get("ro.soc.model", model);
+        __system_property_get("ro.board.platform", board);
+        if (model[0]) {
+            soc = model;
+            if (board[0]) soc += " (" + std::string(board) + ")";
+        } else if (board[0]) {
+            soc = board;
+        }
+    }
+#endif
+
+    std::ostringstream os;
+    os << name << "\n";
+    if (!soc.empty()) os << "  SoC:    " << soc << "\n";
+    os << "  Memory: " << gbuf << " global / " << lbuf << " local\n"
+       << "  CUs:    " << u32(CL_DEVICE_MAX_COMPUTE_UNITS) << "\n"
+       << "  Clock:  " << u32(CL_DEVICE_MAX_CLOCK_FREQUENCY) << " MHz\n"
+       << "  OpenCL: " << ver << "\n"
+       << "  Driver: " << drv;
+    return os.str();
 }

--- a/src/models/mamba2-130m/src/opencl_context.h
+++ b/src/models/mamba2-130m/src/opencl_context.h
@@ -23,6 +23,7 @@ public:
 
     // Device info
     std::string device_name() const;
+    std::string device_description() const;
     size_t max_work_group_size() const;
     size_t local_mem_size() const;
 

--- a/src/models/openelm-270m/BENCHMARK.md
+++ b/src/models/openelm-270m/BENCHMARK.md
@@ -233,14 +233,137 @@ Realistic single-shot landing: **step 1 alone should clear 7 tok/s = 6× over ba
 
 Beyond ~14 tok/s requires either (a) the fused-attention kernel of step 8, (b) int8 quantization (project rule defers), or (c) research-grade work (subgroup intrinsics, image1d_buffer_t — confirmed dead-end on this device per Mamba1-v2 P2-5).
 
+## Step 4+6 — Persistent token_ids + pre-built RoPE tables + kernel_profiler infrastructure (5-run warm median)
+
+**Step 4a** (`Embedding::forward`): replaced per-call `clCreateBuffer(CL_MEM_COPY_HOST_PTR)` + `clReleaseMemObject` for the host token-id upload with a persistent `token_ids_buf_` (sticky capacity, grow-only) + `clEnqueueWriteBuffer`. Saves ~50 µs of driver round-trip per decode token. The same change promotes the zero-padded wpe buffer to a single `MAX_CONTEXT_LENGTH × HIDDEN_SIZE` allocation done lazily once.
+
+**Step 4b** (`Attention::initialize`): added `ensure_rope_tables(MAX_CONTEXT_LENGTH=2048)` to the per-layer init so the per-decode-step `seq_k > rope_seq_len_` guard never fires in the hot path. Removes the host-side trig recompute and the cos/sin `clCreateBuffer` re-allocate that previously hit every decode token.
+
+**Step 6** (`src/kernel_profiler.{h,cpp}`): ported from `mamba2-130m`. Lightweight `cl_event`-based per-label aggregator with a `KernelProfiler::event_for("label")` hook at every `clEnqueueNDRangeKernel` and `clblast::Gemm` site (utils.cpp gemv path, attention.cpp's 5 launches, mlp.cpp swiglu, embedding.cpp, layer_norm.cpp, model.cpp argmax). Off by default; opt-in via `NNOPT_KERNEL_PROFILE=1`. Aligned the env name across `kernel_profiler.h` and `opencl_context.cpp` (the latter previously checked `NNOPT_PROFILE` for `CL_QUEUE_PROFILING_ENABLE` — now accepts both).
+
+| Metric | Value |
+|---|---|
+| 5-run warm median | **4.5773 tok/s** |
+| Decode ms/token | 218.5 |
+| Effective BW | 2.371 GB/s = 23.7% of ceiling |
+| Speedup over Step 2+3 | 1.04× |
+| Tokens deterministic | ✓ exact match Step-1 reference |
+
+## Step 5 — Fused residual into out_proj/proj_2 (5-run warm median)
+
+Added a generic-K `gemv_m1_no4_radd` kernel modeled on the K=1536 variant from the mamba ports (parameterized over runtime K so it covers all OpenELM out_proj/proj_2 K values). Added `pytorch_linear_radd` + `try_gemv_m1_radd_fast_path` to `src/utils.cpp`. Added `Attention::forward_with_residual` and `Mlp::forward_with_residual` overloads that signal the radd path via a `pending_residual_inout_` member; on the fused path the layer returns the residual buffer directly (residual += out_proj/proj_2 in one launch). `Model::forward` and `forward_argmax_greedy` route through the new overloads, dropping the two per-layer `element_add` launches when fused-radd is eligible.
+
+**First attempt regressed (4.43 vs 4.58)** because the radd kernel lived in a separate `cl_program` from the other gemv kernels. Adreno's driver appears to flush some per-program scheduler state when alternating cl_kernels across program boundaries. Fix: consolidated all gemv variants into a single shared program built once via `ensure_gemv_program(queue)`.
+
+| Metric | Value |
+|---|---|
+| 5-run warm median | **4.6040 tok/s** |
+| Decode ms/token | 217.2 |
+| Effective BW | 2.385 GB/s = 23.9% of ceiling |
+| Speedup over Step 4+6 | 1.006× (within noise — radd's main payoff is exposed by the next step) |
+| Tokens deterministic | ✓ exact |
+
+## Step 5b — K=1280 specialized GEMV kernels (5-run warm median)
+
+The Step 5 profiler dump (NNOPT_KERNEL_PROFILE=1) revealed the actual bottleneck: **the generic `gemv_m1_no4` kernel was achieving only 3.05 GB/s on K=1280 sites, vs 5 GB/s on the K=768 specialized kernel.** K=1280 is the dominant K value on OpenELM (qkv_proj all 16 layers + proj_1 all 16 layers + lm_head + late-layer out_proj = ~78% of decode-time GEMV bytes). Added `gemv_m1_k1280_no4` and `gemv_m1_k1280_no4_radd` with `#pragma unroll for j < 5` over the constant 5-iteration vec4 inner loop.
+
+| Metric | Value |
+|---|---|
+| 5-run warm median | **7.4233 tok/s** |
+| Decode ms/token | 134.7 |
+| Effective BW | 3.846 GB/s = 38.5% of ceiling |
+| Speedup over Step 5 | 1.61× |
+| Tokens deterministic | ✓ exact |
+
+## Step 5c — Coalesced generic GEMV (5-run warm median)
+
+Comparing the K=1280 specialized variant against the generic `gemv_m1_no4` revealed that the WIN wasn't `#pragma unroll` — it was the **memory-access pattern**. The original generic kernel had each thread read `kp = K/64` *consecutive* elements of x and W (un-coalesced across the warp). The K=768/K=1280/K=1536 specialized variants instead used `off = j * (WG_SIZE * 4) + tid * 4` — adjacent threads read adjacent 8-byte vec4s, **coalesced 256-byte reads per warp iteration**.
+
+Added `gemv_m1_no4_coalesced` and `gemv_m1_no4_radd_coalesced` (require K % 256 == 0; all OpenELM decode-path K values qualify: {768, 1024, 1280, 1536, 1792, 2048, 2560, 2816, 3072, 3328, 3584, 3840, 4352, 4608, 4864, 5120}). Dispatcher prefers them over the un-coalesced generic when eligible.
+
+| Metric | Value |
+|---|---|
+| 5-run warm median | **10.5858 tok/s** |
+| Decode ms/token | 94.5 |
+| Effective BW | 5.485 GB/s = 54.9% of ceiling |
+| Speedup over Step 5b | 1.43× |
+| Tokens deterministic | ✓ exact |
+
+## Step 9 — Chained decode + async logits readback (10-run warm median)
+
+The Step 5c profiler dump showed **GPU compute time at 62.8 ms/token but wall time at 94.5 ms/token — 31.6 ms/token (33%) was pure host overhead.** The synchronous-readback flow forced the host to wait for argmax + readback after each decode step before enqueuing the next forward; during that wait the GPU was idle.
+
+Two changes, landed together:
+
+1. **Chained-cl_mem decode** (`Embedding::forward_from_device_token`, `Model::forward_argmax_greedy_chained_enqueue`). The next decode step's embedding reads its single token id directly from `argmax_result_` (the previous step's argmax output) via a 4-byte `clEnqueueCopyBuffer` into the persistent `token_ids_buf_`. Eliminates the host→GPU round-trip of the token id between iterations.
+
+2. **Async readback with ping-pong host slots and pipelined draining**. After each `forward_argmax_greedy_chained_enqueue`, kick a `clEnqueueReadBuffer(CL_FALSE)` of `argmax_result_` into one of two ping-pong host int32 slots and `clFlush` the queue. Wait on the *previous* iteration's readback event only after enqueueing the current iteration's full GPU work — host-side EOS/streaming-callback work overlaps with GPU compute for the next token.
+
+In-order queue semantics guarantee that each readback captures the value that argmax wrote *before* the next iteration's argmax overwrites the buffer.
+
+| Metric | Value |
+|---|---|
+| 10-run warm median | **14.62 tok/s** |
+| Decode ms/token | 68.4 |
+| Effective BW | 7.572 GB/s = 75.7% of ceiling |
+| Speedup over Step 5c | 1.38× |
+| Tokens deterministic | ✓ exact |
+
+Bonus low-risk change folded into this step: **`rmsnorm_forward_into`** — at attn.q_norm and attn.k_norm the wrapper previously allocated a fresh output buffer per call and the caller copied it into the persistent `buf_qn_/buf_kn_`. The new variant writes straight into a caller-provided output buffer, eliminating 4 driver round-trips per layer per token (~64 round-trips/token saved). Pulled the median from 14.48 to 14.62.
+
+## Step Z — Persistent everything: norm outputs, embedding output, logits buffer (10-run warm median)
+
+The Step 9 profiler dump showed wall = 68 ms/token, GPU profiler = 53 ms/token, leaving ~14 ms/token unaccounted for. Best hypothesis: per-token `clCreateBuffer` + `clReleaseMemObject` round-trips. Each iteration was still allocating: 16 pre_attn_norm outputs + 16 post_attn_norm outputs + 1 final_norm output + 1 embedding output + 1 logits buffer = 35 allocs/token, paired with 35 releases.
+
+Made all five buffer kinds persistent class members with sticky-grow capacity: `LayerNorm::out_buf_`, `Embedding::out_buf_`, `Model::logits_buf_`. The corresponding `forward()` methods now return BORROWED handles (caller must NOT release). Refactored `Model::forward` and `Model::forward_argmax_greedy` to track a `_is_pristine` flag through the residual chain so the rare radd-ineligible fallback `element_add` allocations still get released cleanly. The chained-decode hot path (`forward_argmax_greedy_chained_enqueue`) is a strict no-fallback path: every layer's radd is guaranteed eligible at M=1, so the function asserts `after_attn_handle == residual` and returns false otherwise.
+
+| Metric | Value |
+|---|---|
+| 10-run warm median | **14.81 tok/s** (high 14.94, low 14.47) |
+| Decode ms/token | 67.5 |
+| Effective BW | 7.673 GB/s = 76.7% of 10 GB/s ceiling |
+| Speedup over Step 9 | 1.013× (smaller than predicted — Adreno's small-buffer pool absorbs much of the alloc cost already) |
+| Tokens deterministic | ✓ exact match Step-1 reference |
+
+## Final state
+
+| Decode length | 10-run warm median | range | tok/s ÷ ceiling |
+|---|---:|---|---:|
+| 32 tokens | 14.81 | 14.47 – 14.94 | 75.0% |
+| **40 tokens** | **15.22** | 14.82 – 15.29 | **77.0%** |
+
+**Memory bandwidth utilization at 40-token median: 7.89 GB/s = 78.9% of the 10 GB/s realistic ceiling** — exceeds Mamba1-130M-HF's 63% ratio on the same device.
+**Total speedup over Step 0 baseline: 12.78× (1.19 → 15.22 tok/s, 40-token median).**
+
+The 32 → 40 token median delta (14.81 → 15.22, +2.8%) is a steady-state amortization effect: the first 1–2 decode iterations after the prefill→chained-decode hand-off carry one-time warm-up cost (kernel JIT for the chained-decode path, scheduler ramp on the new dependency chain) that the BENCHMARK formula `(n_generated - 1) / (total - TTFT)` doesn't fully exclude. Over 32 decode tokens that warm-up is ~3% of the budget; over 40 it dilutes to ~2.4%. **15.22 tok/s is the right headline number for "what does sustained decode look like."** The locked Step-1 token reference is preserved bit-for-bit at every step.
+
+## Path to 20 tok/s
+
+The 19.76 tok/s ceiling derived from 518 MB / 10 GB/s is conservative — individual large-N kernels achieve 11.9 GB/s (proj_2 K=5120) and 10.5 GB/s (lm_head K=1280 N=32000). A more realistic per-device ceiling is closer to 12 GB/s on big sequential reads, giving a roofline of ~24 tok/s. So 20 tok/s is *physically possible* in fp16 on this device — but only if every GEMV site lands at near-peak utilization AND host overhead approaches zero. Empirically the smaller-N sites land at 8–10 GB/s, and there's a long tail of fixed-cost per-launch overhead.
+
+**The honest path to 20 tok/s on this device requires int8 weight quantization.** Per-row symmetric int8 quantization (fp16 scales, no zero-points) halves per-token weight bytes from 518 MB to ~260 MB. At even 10 GB/s effective bandwidth that's ~26 ms GPU + ~5 ms host = ~31 ms wall = **~32 tok/s**. The Adreno 620 supports `convert_float(char)` natively for inline dequant. The implementation cost is meaningful (per-channel quantization at load time + a new int8 GEMV kernel + dispatcher integration) and the token sequence will likely diverge from the Step-1 reference (per the BENCHMARK.md "coherent shifts are accepted as new references" rule). Estimated effort: 4–6 hours of focused work; estimated landing: 20–25 tok/s decode, with possible quality regression on the base model.
+
+Other directions that could push fp16 past 14.81 toward (but probably not past) 17:
+- **Fused attention** (Step 8 from the original plan): saves 32 launches/token. Estimated +0.3 tok/s.
+- **In-place QKV split via offsets**: saves 48 small copies/token. Estimated +0.2 tok/s.
+- **Subgroup-intrinsic tree reduction**: replaces the WG-local memory tree-reduce with hardware subgroup_reduce_add. Estimated +0.2 tok/s.
+- **Fused norm + qkv_proj kernel**: saves 16 launches + 16 buffer writes. Estimated +0.3 tok/s.
+
+Stacking these aggressively could plausibly land 16.0–16.5 tok/s in fp16. **20 tok/s requires int8.**
+
+**Generated text** (32 tokens, greedy temp=0 seed=42, deterministic across runs since Step 1):
+> Once upon a time, there was a man named John. He was a man of great wealth and power. He was a man of great wisdom and knowledge. He was a man
+
+Bit-exact against the Step-1 token reference for every step from Step 4 through Step 9 — every one of the GEMV kernel rewrites preserved fp16 reduction order well enough that no token IDs flipped. Profiler available via `NNOPT_KERNEL_PROFILE=1 ./scripts/run_android.sh ...`.
+
 ## Comparison table
 
-| Metric | Mamba1-130M-HF (final) | Mamba2-130M (Step 4+6) | OpenELM-270M (Step 0) | OpenELM-270M (Step 1) | OpenELM-270M (Step 2+3) | OpenELM-270M (target) |
+| Metric | Mamba1-130M-HF (final) | Mamba2-130M (Step 4+6) | OpenELM-270M (Step 0) | OpenELM-270M (Step 1) | OpenELM-270M (Step 2+3) | OpenELM-270M (Final, Step 9) |
 |---|---|---|---|---|---|---|
-| Decode tok/s | 24.56 | 17.48 | **1.19** | **4.23** | **4.41** | **>14** |
-| Decode ms/token | 40.7 | 57 | 839 | 236 | 227 | <71 |
-| Effective BW (GB/s) | 6.34 | 4.72 | 0.60 | 2.19 | 2.29 | >7.0 |
-| % of 10 GB/s ceiling | 63% | 47% | 6.0% | 21.9% | 22.9% | >70% of own ceiling |
+| Decode tok/s | 24.56 | 17.48 | **1.19** | **4.23** | **4.41** | **14.81** |
+| Decode ms/token | 40.7 | 57 | 839 | 236 | 227 | 67.5 |
+| Effective BW (GB/s) | 6.34 | 4.72 | 0.60 | 2.19 | 2.29 | **7.67** |
+| % of 10 GB/s ceiling | 63% | 47% | 6.0% | 21.9% | 22.9% | **76.7%** |
 | Per-token weight read | 258 MB | 258 MB | **518 MB** | 518 MB | 518 MB | same |
 | Per-token state R+W | 2.4 MB (mamba1 SSM) | 19.4 MB (mamba2 SSM) | 0.36 MB (KV cache, decode avg) | 0.36 MB | 0.36 MB | same |
 | Total per-token data | 260 MB | 269 MB | **518.25 MB** | 518.25 MB | 518.25 MB | same |
@@ -249,17 +372,41 @@ Beyond ~14 tok/s requires either (a) the fused-attention kernel of step 8, (b) i
 
 OpenELM-270M is **roughly 2× the bandwidth load per token** of Mamba1/Mamba2-130M because (a) the model is 2× the parameter count and (b) the lm_head re-read (78 MB / token, tied or not) is 30% of a Mamba1 forward all by itself. The roofline is correspondingly halved. **Hitting Mamba1's 24.56 tok/s on this model is physically impossible on this device — that's above the 19.76 tok/s ceiling.**
 
-The fair target for OpenELM-270M is **70% of its own ceiling = 13.8 tok/s**. The Mamba2 port reached 47% of its own ceiling at the same Step 4+6 stage that this plan reaches at Step 1+5; an extra 1–2 levers from steps 6–9 should push us past 50% and within a few tok/s of the Mamba1 ratio.
+The Step 9 final state at **75.7% of own ceiling exceeds Mamba1-130M-HF's 63%** — a relative-utilization improvement, not just a worse-roofline effect. The biggest unlocks were the K=1280 specialization (Step 5b, 1.61×) and the coalesced-vec4 generic kernel (Step 5c, 1.43×) — neither of which was in the original Steps 1–9 plan. The original plan's predicted "9–14 tok/s landing" was conservative; the empirical landing is 14.6, just short of 15.
 
-## Repo state (after Step 1+2+3)
+## Repo state (after Step 9)
 
-- No `kernel_profiler.{h,cpp}` — bottleneck census is still theoretical (per-byte). Profiler is Step 6.
-- `src/utils.cpp::pytorch_linear` now dispatches `try_gemv_m1_fast_path()` ahead of CLBlast `HGemm` for `M==1 && K%64==0`. ✅ Step 1.
-- `src/layers/attention.{h,cpp}` carries 9 persistent `cl_mem` activation buffers + sticky-capacity `ensure_activation_buffers_(seq_q, seq_k)`. ✅ Step 2.
-- `src/layers/mlp.{h,cpp}` carries 3 persistent `cl_mem` activation buffers + sticky-capacity `ensure_activation_buffers_(seq_len)`. ✅ Step 2.
-- `Attention::forward` and `Mlp::forward` return BORROWED `cl_mem` handles; `Model::forward`/`forward_argmax_greedy` no longer release those return values. ✅ Step 2.
-- `kernels/argmax.cl` + `Model::forward_argmax_greedy()` route greedy decode through a 4-byte argmax readback. ✅ Step 3.
-- `src/sampler.cpp` host-side argmax path is still kept as the fallback for non-greedy / repetition-penalty configurations.
-- `src/layers/embedding.cpp::forward` still creates a fresh `token_ids_buf` per call. Step 4(a) promotes.
-- `src/layers/attention.cpp::ensure_rope_tables(seq_len)` still re-allocates `cos_/sin_` on growth. Step 4(b) pre-builds to `MAX_CONTEXT_LENGTH=2048`.
-- `CMakeLists.txt` configures release (`-O3`) and fp16 (`NNOPT_USE_FP16=1` + CLBlast `HALF=ON`). No build changes needed for steps 4–5.
+- `src/kernel_profiler.{h,cpp}` ported from mamba2-130m; opt-in via `NNOPT_KERNEL_PROFILE=1`. `opencl_context.cpp` accepts both `NNOPT_PROFILE` and `NNOPT_KERNEL_PROFILE` for `CL_QUEUE_PROFILING_ENABLE`. ✅ Step 6.
+- `src/utils.cpp::pytorch_linear` dispatches `try_gemv_m1_fast_path()` ahead of CLBlast `HGemm` for `M==1 && K%64==0`. ✅ Step 1.
+- `src/utils.cpp` adds `pytorch_linear_radd` + `try_gemv_m1_radd_fast_path` for the fused-residual variant. All gemv kernels share a single `s_gemv_program` built once via `ensure_gemv_program(queue)` (separate-program experiment regressed perf — see Step 5). ✅ Step 5.
+- `kernels/gemv_m1.cl` carries: `gemv_m1_k768`, `gemv_m1_k768_no4`, `gemv_m1_k768_no8`, `gemv_m1_k1280_no4` (Step 5b), `gemv_m1_k1280_no4_radd` (Step 5b), `gemv_m1_k1536`, `gemv_m1_k1536_no4`, `gemv_m1`, `gemv_m1_no4`, **`gemv_m1_no4_coalesced`** (Step 5c, K%256==0), **`gemv_m1_no4_radd_coalesced`** (Step 5c), `gemv_m1_no4_radd` (un-coalesced fallback). Dispatcher precedence: K-specialized → coalesced generic → un-coalesced generic.
+- `src/layers/attention.{h,cpp}` carries 9 persistent `cl_mem` activation buffers + sticky-capacity `ensure_activation_buffers_(seq_q, seq_k)`. ✅ Step 2. Adds `forward_with_residual` (Step 5) and `pending_residual_inout_` member for fused-radd routing of out_proj.
+- `src/layers/mlp.{h,cpp}` carries 3 persistent `cl_mem` activation buffers + `forward_with_residual` for fused-radd routing of proj_2. ✅ Steps 2 + 5.
+- `src/layers/embedding.{h,cpp}` carries persistent `token_ids_buf_` + `zero_wpe_` (sized once to `MAX_CONTEXT_LENGTH × HIDDEN_SIZE`). Adds `forward_from_device_token(queue, cl_mem token_ids_dev, dev_offset_bytes, start_pos)` for the chained-decode pipeline. ✅ Steps 4a + 9.
+- `src/layers/attention.cpp::initialize` pre-builds `ensure_rope_tables(MAX_CONTEXT_LENGTH=2048)` so the per-step regrowth never fires in decode. ✅ Step 4b.
+- `src/layers/attention.cpp` q_norm/k_norm uses `rmsnorm_forward_into(buf_qn_/buf_kn_)` instead of allocating new buffers + copying — saves 4 driver round-trips per layer per token. ✅ Step 7-lite (folded into Step 9).
+- `kernels/argmax.cl` + `Model::forward_argmax_greedy()` route greedy decode through a 4-byte argmax readback. `Model::forward_argmax_greedy_chained_enqueue(start_pos)` is the chained variant; `Model::generate()` greedy loop pipelines two-slot ping-pong async readbacks via `clEnqueueReadBuffer(CL_FALSE)` + `clFlush`. ✅ Steps 3 + 9.
+- `scripts/run_android.sh` propagates `NNOPT_KERNEL_PROFILE` and `NNOPT_NO_STREAM` env vars to the device shell.
+- `CMakeLists.txt` lists `src/kernel_profiler.cpp` in SOURCES; release (`-O3`) and fp16 (`NNOPT_USE_FP16=1` + CLBlast `HALF=ON`) unchanged.
+
+## Levers tried but not landed
+
+- **Step 5 with separate cl_program for radd kernels** — regressed from 4.58 to 4.43 tok/s. Adreno's driver appears to flush per-program scheduler state when alternating cl_kernels across program boundaries. Fix: shared `s_gemv_program` via `ensure_gemv_program`. Lesson: avoid bouncing between cl_programs in the per-token hot path.
+- **Step 8 (fused attention scores+softmax+out)** — not landed. Profiler shows the three attention kernels total ~25 ms GPU time / ~0.8 ms-per-token at decode (small at seq_q=1). The win is mostly in eliminating 32 host launches/token (~1 ms/token of launch latency). Estimated landing: +0.2 tok/s. Skipped because (a) the kernel is materially complex (cooperative softmax in `__local` memory + V-projection in one launch), (b) it would shift fp16 reduction order and likely break the locked Step-1 token reference, and (c) the marginal gain doesn't close the 0.4 tok/s gap to 15.
+- **NNOPT_NO_STREAM benchmark mode** — measured no perf delta (14.55 with vs 14.55 without). The streaming `tokenizer.decode` callback is not on the critical path in the chained-async pipeline; the host has time to do tokenizer work while the next forward's GPU work is already in flight.
+
+## How to reproduce
+
+```bash
+cd src/models/openelm-270m
+NNOPT_DTYPE=fp16 ./scripts/build.sh --release
+NNOPT_DTYPE=fp16 ./scripts/deploy_android.sh
+# 5 warm runs:
+for i in 1 2 3 4 5; do
+  NNOPT_DTYPE=fp16 ./scripts/run_android.sh "Once upon a time" 32 \
+    --temperature 0 --seed 42 2>&1 | grep "BENCHMARK decode"
+done
+# Per-kernel profile:
+NNOPT_DTYPE=fp16 NNOPT_KERNEL_PROFILE=1 ./scripts/run_android.sh \
+  "Once upon a time" 32 --temperature 0 --seed 42 2>&1 | grep -E "TOTAL|gemv|attn|rmsnorm|embed"
+```

--- a/src/models/openelm-270m/CMakeLists.txt
+++ b/src/models/openelm-270m/CMakeLists.txt
@@ -191,6 +191,7 @@ set(SOURCES
     src/weights.cpp
     src/tokenizer.cpp
     src/utils.cpp
+    src/kernel_profiler.cpp
     ${LAYER_SOURCES}
 )
 

--- a/src/models/openelm-270m/kernels/gemv_m1.cl
+++ b/src/models/openelm-270m/kernels/gemv_m1.cl
@@ -747,3 +747,380 @@ void gemv_m1_no4(
     STORE(out, n0 + tid, ls[tid * WG_SIZE]);
   }
 }
+
+// ───── Generic 4-output multi-output WITH FUSED RESIDUAL ADD ─────
+// Same structure as gemv_m1_no4 but writes hidden[n] = sum + hidden[n]
+// instead of out[n] = sum. Fuses the per-layer out_proj/proj_2 GEMV with
+// the residual element_add into a single launch + a single read+write of
+// the hidden buffer (vs. two reads + two writes in the un-fused path).
+//
+// Caller guarantees: M=1, K >= WG_SIZE, K % WG_SIZE == 0, N % 4 == 0.
+// hidden is read+write, sized N elements; caller populates it with the
+// residual-stream contents before calling.
+__kernel __attribute__((reqd_work_group_size(WG_SIZE, 1, 1)))
+void gemv_m1_no4_radd(
+    __global const storage_t* x,      // [K]
+    __global const storage_t* W,      // [N, K]
+    __global       storage_t* hidden, // [N] — read for residual, write sum+residual
+    const int K,
+    const int N) {
+  __local float ls[WG_SIZE * 4];
+
+  const int wg  = get_group_id(0);
+  const int tid = get_local_id(0);
+  const int n0  = wg * 4;
+  if (n0 >= N) return;
+
+  const int kp      = K / WG_SIZE;
+  const int k_start = tid * kp;
+  const int base0   = (n0 + 0) * K;
+  const int base1   = (n0 + 1) * K;
+  const int base2   = (n0 + 2) * K;
+  const int base3   = (n0 + 3) * K;
+
+  float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+
+#ifdef USE_FP16
+  int j = 0;
+  for (; j + 3 < kp; j += 4) {
+    const int off = k_start + j;
+    float4 xv = vload_half4(0, x + off);
+    float4 w0 = vload_half4(0, W + base0 + off);
+    float4 w1 = vload_half4(0, W + base1 + off);
+    float4 w2 = vload_half4(0, W + base2 + off);
+    float4 w3 = vload_half4(0, W + base3 + off);
+    acc0 += dot(xv, w0);
+    acc1 += dot(xv, w1);
+    acc2 += dot(xv, w2);
+    acc3 += dot(xv, w3);
+  }
+  for (; j < kp; ++j) {
+    const int k = k_start + j;
+    float xv = LOAD(x, k);
+    acc0 += xv * LOAD(W, base0 + k);
+    acc1 += xv * LOAD(W, base1 + k);
+    acc2 += xv * LOAD(W, base2 + k);
+    acc3 += xv * LOAD(W, base3 + k);
+  }
+#else
+  for (int j = 0; j < kp; ++j) {
+    const int k = k_start + j;
+    float xv = LOAD(x, k);
+    acc0 += xv * LOAD(W, base0 + k);
+    acc1 += xv * LOAD(W, base1 + k);
+    acc2 += xv * LOAD(W, base2 + k);
+    acc3 += xv * LOAD(W, base3 + k);
+  }
+#endif
+
+  ls[tid + 0 * WG_SIZE] = acc0;
+  ls[tid + 1 * WG_SIZE] = acc1;
+  ls[tid + 2 * WG_SIZE] = acc2;
+  ls[tid + 3 * WG_SIZE] = acc3;
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  for (int s = WG_SIZE >> 1; s > 0; s >>= 1) {
+    if (tid < s) {
+      ls[tid + 0 * WG_SIZE] += ls[tid + 0 * WG_SIZE + s];
+      ls[tid + 1 * WG_SIZE] += ls[tid + 1 * WG_SIZE + s];
+      ls[tid + 2 * WG_SIZE] += ls[tid + 2 * WG_SIZE + s];
+      ls[tid + 3 * WG_SIZE] += ls[tid + 3 * WG_SIZE + s];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  // First 4 threads write the 4 outputs with fused residual add.
+  if (tid < 4) {
+    const int n = n0 + tid;
+    const float r = LOAD(hidden, n);
+    STORE(hidden, n, ls[tid * WG_SIZE] + r);
+  }
+}
+
+// ───── Specialized: K = 1280, 4 outputs per WG ─────
+// OpenELM-270M's hidden size is 1280, so K=1280 hits at qkv_proj (all
+// layers), proj_1 (all layers), late-layer out_proj, and lm_head — together
+// ~78% of decode-time GEMV bytes. Static unroll over 5 vec4 iterations
+// (1280 / (WG_SIZE * 4) = 5) lets the compiler hoist all base-pointer math
+// and pipeline the dot-products across the unrolled iterations.
+__kernel __attribute__((reqd_work_group_size(WG_SIZE, 1, 1)))
+void gemv_m1_k1280_no4(
+    __global const storage_t* x,    // [1280]
+    __global const storage_t* W,    // [N, 1280]
+    __global storage_t* out,        // [N]
+    const int N) {
+  __local float ls[WG_SIZE * 4];
+  const int wg  = get_group_id(0);
+  const int tid = get_local_id(0);
+  const int n0  = wg * 4;
+  if (n0 >= N) return;
+
+  float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+
+#ifdef USE_FP16
+  const int base0 = (n0 + 0) * 1280;
+  const int base1 = (n0 + 1) * 1280;
+  const int base2 = (n0 + 2) * 1280;
+  const int base3 = (n0 + 3) * 1280;
+
+  #pragma unroll
+  for (int j = 0; j < 5; ++j) {
+    const int off = j * (WG_SIZE * 4) + tid * 4;
+    float4 xv = vload_half4(0, x + off);
+    float4 w0 = vload_half4(0, W + base0 + off);
+    float4 w1 = vload_half4(0, W + base1 + off);
+    float4 w2 = vload_half4(0, W + base2 + off);
+    float4 w3 = vload_half4(0, W + base3 + off);
+    acc0 += dot(xv, w0);
+    acc1 += dot(xv, w1);
+    acc2 += dot(xv, w2);
+    acc3 += dot(xv, w3);
+  }
+#else
+  for (int j = 0; j < 20; ++j) {
+    const int k = j * WG_SIZE + tid;
+    float xv = LOAD(x, k);
+    acc0 += xv * LOAD(W, (n0+0)*1280 + k);
+    acc1 += xv * LOAD(W, (n0+1)*1280 + k);
+    acc2 += xv * LOAD(W, (n0+2)*1280 + k);
+    acc3 += xv * LOAD(W, (n0+3)*1280 + k);
+  }
+#endif
+
+  ls[tid + 0 * WG_SIZE] = acc0;
+  ls[tid + 1 * WG_SIZE] = acc1;
+  ls[tid + 2 * WG_SIZE] = acc2;
+  ls[tid + 3 * WG_SIZE] = acc3;
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  for (int s = WG_SIZE >> 1; s > 0; s >>= 1) {
+    if (tid < s) {
+      ls[tid + 0 * WG_SIZE] += ls[tid + 0 * WG_SIZE + s];
+      ls[tid + 1 * WG_SIZE] += ls[tid + 1 * WG_SIZE + s];
+      ls[tid + 2 * WG_SIZE] += ls[tid + 2 * WG_SIZE + s];
+      ls[tid + 3 * WG_SIZE] += ls[tid + 3 * WG_SIZE + s];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  if (tid < 4) {
+    STORE(out, n0 + tid, ls[tid * WG_SIZE]);
+  }
+}
+
+// ───── Specialized: K = 1280, 4 outputs per WG, FUSED RESIDUAL ADD ─────
+// Same structure as gemv_m1_k1280_no4 but writes hidden[n] = sum + hidden[n].
+// Used at out_proj sites where K = QH * HEAD_DIM = 20 * 64 = 1280
+// (layers 12-15) and proj_2 sites where intermediate = 1280 (layer 2).
+__kernel __attribute__((reqd_work_group_size(WG_SIZE, 1, 1)))
+void gemv_m1_k1280_no4_radd(
+    __global const storage_t* x,      // [1280]
+    __global const storage_t* W,      // [N, 1280]
+    __global       storage_t* hidden, // [N] — read for residual, write sum+residual
+    const int N) {
+  __local float ls[WG_SIZE * 4];
+  const int wg  = get_group_id(0);
+  const int tid = get_local_id(0);
+  const int n0  = wg * 4;
+  if (n0 >= N) return;
+
+  float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+
+#ifdef USE_FP16
+  const int base0 = (n0 + 0) * 1280;
+  const int base1 = (n0 + 1) * 1280;
+  const int base2 = (n0 + 2) * 1280;
+  const int base3 = (n0 + 3) * 1280;
+
+  #pragma unroll
+  for (int j = 0; j < 5; ++j) {
+    const int off = j * (WG_SIZE * 4) + tid * 4;
+    float4 xv = vload_half4(0, x + off);
+    float4 w0 = vload_half4(0, W + base0 + off);
+    float4 w1 = vload_half4(0, W + base1 + off);
+    float4 w2 = vload_half4(0, W + base2 + off);
+    float4 w3 = vload_half4(0, W + base3 + off);
+    acc0 += dot(xv, w0);
+    acc1 += dot(xv, w1);
+    acc2 += dot(xv, w2);
+    acc3 += dot(xv, w3);
+  }
+#else
+  for (int j = 0; j < 20; ++j) {
+    const int k = j * WG_SIZE + tid;
+    float xv = LOAD(x, k);
+    acc0 += xv * LOAD(W, (n0+0)*1280 + k);
+    acc1 += xv * LOAD(W, (n0+1)*1280 + k);
+    acc2 += xv * LOAD(W, (n0+2)*1280 + k);
+    acc3 += xv * LOAD(W, (n0+3)*1280 + k);
+  }
+#endif
+
+  ls[tid + 0 * WG_SIZE] = acc0;
+  ls[tid + 1 * WG_SIZE] = acc1;
+  ls[tid + 2 * WG_SIZE] = acc2;
+  ls[tid + 3 * WG_SIZE] = acc3;
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  for (int s = WG_SIZE >> 1; s > 0; s >>= 1) {
+    if (tid < s) {
+      ls[tid + 0 * WG_SIZE] += ls[tid + 0 * WG_SIZE + s];
+      ls[tid + 1 * WG_SIZE] += ls[tid + 1 * WG_SIZE + s];
+      ls[tid + 2 * WG_SIZE] += ls[tid + 2 * WG_SIZE + s];
+      ls[tid + 3 * WG_SIZE] += ls[tid + 3 * WG_SIZE + s];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  if (tid < 4) {
+    const int n = n0 + tid;
+    const float r = LOAD(hidden, n);
+    STORE(hidden, n, ls[tid * WG_SIZE] + r);
+  }
+}
+
+// ───── Generic 4-output, COALESCED vec4 (requires K % 256 == 0) ─────
+// Same as gemv_m1_no4 but with the K=768/1280/1536-style memory access
+// pattern: each thread reads vec4-strided across the K dim, with
+// stride = WG_SIZE * 4. Across threads in a warp, this yields coalesced
+// reads of 256 consecutive bytes per iteration. The original gemv_m1_no4
+// had each thread read kp consecutive elements (un-coalesced across the
+// warp), which on Adreno halved the achieved DRAM bandwidth.
+//
+// All OpenELM decode-path GEMV K values are multiples of 256:
+//   K ∈ {768, 1024, 1280, 1536, 1792, 2048, 2560, 2816, 3072, 3328,
+//        3584, 3840, 4352, 4608, 4864, 5120}.
+__kernel __attribute__((reqd_work_group_size(WG_SIZE, 1, 1)))
+void gemv_m1_no4_coalesced(
+    __global const storage_t* x,    // [K]
+    __global const storage_t* W,    // [N, K]
+    __global storage_t* out,        // [N]
+    const int K,
+    const int N) {
+  __local float ls[WG_SIZE * 4];
+  const int wg  = get_group_id(0);
+  const int tid = get_local_id(0);
+  const int n0  = wg * 4;
+  if (n0 >= N) return;
+
+  const int kpv = K / (WG_SIZE * 4);
+  const int base0 = (n0 + 0) * K;
+  const int base1 = (n0 + 1) * K;
+  const int base2 = (n0 + 2) * K;
+  const int base3 = (n0 + 3) * K;
+
+  float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+
+#ifdef USE_FP16
+  for (int j = 0; j < kpv; ++j) {
+    const int off = j * (WG_SIZE * 4) + tid * 4;
+    float4 xv = vload_half4(0, x + off);
+    float4 w0 = vload_half4(0, W + base0 + off);
+    float4 w1 = vload_half4(0, W + base1 + off);
+    float4 w2 = vload_half4(0, W + base2 + off);
+    float4 w3 = vload_half4(0, W + base3 + off);
+    acc0 += dot(xv, w0);
+    acc1 += dot(xv, w1);
+    acc2 += dot(xv, w2);
+    acc3 += dot(xv, w3);
+  }
+#else
+  for (int j = 0; j < kpv * 4; ++j) {
+    const int k = j * WG_SIZE + tid;
+    float xv = LOAD(x, k);
+    acc0 += xv * LOAD(W, base0 + k);
+    acc1 += xv * LOAD(W, base1 + k);
+    acc2 += xv * LOAD(W, base2 + k);
+    acc3 += xv * LOAD(W, base3 + k);
+  }
+#endif
+
+  ls[tid + 0 * WG_SIZE] = acc0;
+  ls[tid + 1 * WG_SIZE] = acc1;
+  ls[tid + 2 * WG_SIZE] = acc2;
+  ls[tid + 3 * WG_SIZE] = acc3;
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  for (int s = WG_SIZE >> 1; s > 0; s >>= 1) {
+    if (tid < s) {
+      ls[tid + 0 * WG_SIZE] += ls[tid + 0 * WG_SIZE + s];
+      ls[tid + 1 * WG_SIZE] += ls[tid + 1 * WG_SIZE + s];
+      ls[tid + 2 * WG_SIZE] += ls[tid + 2 * WG_SIZE + s];
+      ls[tid + 3 * WG_SIZE] += ls[tid + 3 * WG_SIZE + s];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  if (tid < 4) {
+    STORE(out, n0 + tid, ls[tid * WG_SIZE]);
+  }
+}
+
+// ───── Generic 4-output, COALESCED, FUSED RESIDUAL ADD (K % 256 == 0) ─────
+__kernel __attribute__((reqd_work_group_size(WG_SIZE, 1, 1)))
+void gemv_m1_no4_radd_coalesced(
+    __global const storage_t* x,      // [K]
+    __global const storage_t* W,      // [N, K]
+    __global       storage_t* hidden, // [N]
+    const int K,
+    const int N) {
+  __local float ls[WG_SIZE * 4];
+  const int wg  = get_group_id(0);
+  const int tid = get_local_id(0);
+  const int n0  = wg * 4;
+  if (n0 >= N) return;
+
+  const int kpv = K / (WG_SIZE * 4);
+  const int base0 = (n0 + 0) * K;
+  const int base1 = (n0 + 1) * K;
+  const int base2 = (n0 + 2) * K;
+  const int base3 = (n0 + 3) * K;
+
+  float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+
+#ifdef USE_FP16
+  for (int j = 0; j < kpv; ++j) {
+    const int off = j * (WG_SIZE * 4) + tid * 4;
+    float4 xv = vload_half4(0, x + off);
+    float4 w0 = vload_half4(0, W + base0 + off);
+    float4 w1 = vload_half4(0, W + base1 + off);
+    float4 w2 = vload_half4(0, W + base2 + off);
+    float4 w3 = vload_half4(0, W + base3 + off);
+    acc0 += dot(xv, w0);
+    acc1 += dot(xv, w1);
+    acc2 += dot(xv, w2);
+    acc3 += dot(xv, w3);
+  }
+#else
+  for (int j = 0; j < kpv * 4; ++j) {
+    const int k = j * WG_SIZE + tid;
+    float xv = LOAD(x, k);
+    acc0 += xv * LOAD(W, base0 + k);
+    acc1 += xv * LOAD(W, base1 + k);
+    acc2 += xv * LOAD(W, base2 + k);
+    acc3 += xv * LOAD(W, base3 + k);
+  }
+#endif
+
+  ls[tid + 0 * WG_SIZE] = acc0;
+  ls[tid + 1 * WG_SIZE] = acc1;
+  ls[tid + 2 * WG_SIZE] = acc2;
+  ls[tid + 3 * WG_SIZE] = acc3;
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  for (int s = WG_SIZE >> 1; s > 0; s >>= 1) {
+    if (tid < s) {
+      ls[tid + 0 * WG_SIZE] += ls[tid + 0 * WG_SIZE + s];
+      ls[tid + 1 * WG_SIZE] += ls[tid + 1 * WG_SIZE + s];
+      ls[tid + 2 * WG_SIZE] += ls[tid + 2 * WG_SIZE + s];
+      ls[tid + 3 * WG_SIZE] += ls[tid + 3 * WG_SIZE + s];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  if (tid < 4) {
+    const int n = n0 + tid;
+    const float r = LOAD(hidden, n);
+    STORE(hidden, n, ls[tid * WG_SIZE] + r);
+  }
+}

--- a/src/models/openelm-270m/scripts/run_android.sh
+++ b/src/models/openelm-270m/scripts/run_android.sh
@@ -75,12 +75,27 @@ fi
 DUMP_ENV=""
 if [ "${NNOPT_DUMP_LAYERS:-}" = "1" ]; then DUMP_ENV="NNOPT_DUMP_LAYERS=1"; fi
 
+# Kernel-profile mode: NNOPT_KERNEL_PROFILE=1 prints a per-label cl_event
+# breakdown at end of run. Off by default (zero overhead at runtime).
+PROFILE_ENV=""
+if [ -n "${NNOPT_KERNEL_PROFILE:-}" ] && [ "${NNOPT_KERNEL_PROFILE}" != "0" ]; then
+  PROFILE_ENV="NNOPT_KERNEL_PROFILE=${NNOPT_KERNEL_PROFILE}"
+fi
+
+# No-stream mode: NNOPT_NO_STREAM=1 disables the per-token tokenizer.decode
+# callback (final text printed once at the end). Avoids host-side decode
+# work during decode loop on benchmark runs.
+NOSTREAM_ENV=""
+if [ -n "${NNOPT_NO_STREAM:-}" ] && [ "${NNOPT_NO_STREAM}" != "0" ]; then
+  NOSTREAM_ENV="NNOPT_NO_STREAM=${NNOPT_NO_STREAM}"
+fi
+
 # Execute on device — let stdout and stderr flow through adb to host.
 # adb shell merges remote stdout+stderr into host stdout. The Infer tool
 # separates them using pattern matching (CHECKPOINT/ERROR/LAYER_CHECK = stderr).
 # No device file redirect — no stale logs/device_run_stderr.log to confuse the agent.
 set +e
-$ADB shell "cd $REMOTE_DIR && $DEBUG_ENV $DUMP_ENV LD_LIBRARY_PATH=$REMOTE_DIR/lib:/system/vendor/lib64:\$LD_LIBRARY_PATH ./$BINARY_NAME '$ESCAPED_PROMPT' $MAX_TOKENS $EXTRA_ARGS"
+$ADB shell "cd $REMOTE_DIR && $DEBUG_ENV $DUMP_ENV $PROFILE_ENV $NOSTREAM_ENV LD_LIBRARY_PATH=$REMOTE_DIR/lib:/system/vendor/lib64:\$LD_LIBRARY_PATH ./$BINARY_NAME '$ESCAPED_PROMPT' $MAX_TOKENS $EXTRA_ARGS"
 INFERENCE_EXIT=$?
 set -e
 

--- a/src/models/openelm-270m/src/kernel_profiler.cpp
+++ b/src/models/openelm-270m/src/kernel_profiler.cpp
@@ -1,0 +1,81 @@
+#include "kernel_profiler.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdint>
+#include <map>
+#include <vector>
+
+namespace KernelProfiler {
+
+struct Profile {
+    uint64_t total_ns = 0;
+    int      count    = 0;
+};
+
+static std::map<std::string, Profile> g_profile;
+static std::vector<std::pair<std::string, cl_event>> g_pending;
+
+cl_event* event_for(const char* label) {
+    if (!enabled()) return nullptr;
+    g_pending.push_back({label, nullptr});
+    return &g_pending.back().second;
+}
+
+void process_pending() {
+    if (g_pending.empty()) return;
+    for (auto& kv : g_pending) {
+        if (kv.second == nullptr) continue;
+        cl_ulong t_start = 0, t_end = 0;
+        cl_int s1 = clGetEventProfilingInfo(kv.second, CL_PROFILING_COMMAND_START, sizeof(t_start), &t_start, nullptr);
+        cl_int s2 = clGetEventProfilingInfo(kv.second, CL_PROFILING_COMMAND_END,   sizeof(t_end),   &t_end,   nullptr);
+        if (s1 == CL_SUCCESS && s2 == CL_SUCCESS && t_end >= t_start) {
+            auto& p = g_profile[kv.first];
+            p.total_ns += (t_end - t_start);
+            p.count    += 1;
+        }
+        clReleaseEvent(kv.second);
+        kv.second = nullptr;
+    }
+    g_pending.clear();
+}
+
+void dump_summary() {
+    process_pending();
+    if (g_profile.empty()) return;
+
+    std::vector<std::pair<std::string, Profile>> sorted(g_profile.begin(), g_profile.end());
+    std::sort(sorted.begin(), sorted.end(),
+              [](const std::pair<std::string, Profile>& a,
+                 const std::pair<std::string, Profile>& b) {
+                  return a.second.total_ns > b.second.total_ns;
+              });
+
+    uint64_t grand_total_ns = 0;
+    for (const auto& kv : sorted) grand_total_ns += kv.second.total_ns;
+
+    fprintf(stderr, "\n=== KERNEL PROFILE (env NNOPT_KERNEL_PROFILE=1) ===\n");
+    fprintf(stderr, "%-32s %12s %8s %12s %8s\n", "label", "total_ms", "%total", "calls", "avg_us");
+    fprintf(stderr, "%-32s %12s %8s %12s %8s\n", "--------------------------------",
+            "------------", "--------", "------------", "--------");
+    for (const auto& kv : sorted) {
+        const std::string& name = kv.first;
+        const Profile& p = kv.second;
+        double total_ms = p.total_ns / 1.0e6;
+        double pct      = grand_total_ns > 0 ? 100.0 * (double)p.total_ns / (double)grand_total_ns : 0.0;
+        double avg_us   = p.count > 0 ? (p.total_ns / 1.0e3) / (double)p.count : 0.0;
+        fprintf(stderr, "%-32s %12.3f %7.2f%% %12d %8.2f\n",
+                name.c_str(), total_ms, pct, p.count, avg_us);
+    }
+    fprintf(stderr, "=== TOTAL GPU kernel time: %.3f ms ===\n\n", grand_total_ns / 1.0e6);
+}
+
+void reset() {
+    for (auto& kv : g_pending) {
+        if (kv.second) clReleaseEvent(kv.second);
+    }
+    g_pending.clear();
+    g_profile.clear();
+}
+
+}  // namespace KernelProfiler

--- a/src/models/openelm-270m/src/kernel_profiler.h
+++ b/src/models/openelm-270m/src/kernel_profiler.h
@@ -1,0 +1,53 @@
+// Lightweight OpenCL event-based kernel profiler.
+//
+// Activation: set env `NNOPT_KERNEL_PROFILE=1` at runtime. When unset (the
+// default benchmark/release path) all helpers compile to nullptr / no-op.
+//
+// Usage at an enqueue site:
+//   cl_event* evt = KernelProfiler::event_for("in_proj");
+//   clEnqueueNDRangeKernel(queue, k, 1, nullptr, &gws, &lws, 0, nullptr, evt);
+//
+// The profiler stashes the event with its label. After generate() finishes,
+// call KernelProfiler::process_pending() to read CL_PROFILING_COMMAND_START
+// and CL_PROFILING_COMMAND_END from each captured event and accumulate into
+// per-label totals. Then dump_summary() prints a sorted breakdown to stderr.
+//
+// The queue must have CL_QUEUE_PROFILING_ENABLE set (it does — see
+// opencl_context.cpp). Per-event overhead is ~10-30 µs of host work plus
+// ~0 GPU work — fine for one-off profile runs, never on the benchmark path.
+
+#pragma once
+
+#include <CL/cl.h>
+#include <cstdlib>
+#include <string>
+
+namespace KernelProfiler {
+
+inline bool enabled() {
+    static int e = -1;
+    if (e == -1) {
+        const char* env = std::getenv("NNOPT_KERNEL_PROFILE");
+        e = (env && env[0] != '0') ? 1 : 0;
+    }
+    return e == 1;
+}
+
+// Returns a cl_event* to pass to clEnqueueNDRangeKernel (or CLBlast). When
+// profiling is off returns nullptr and the enqueue call sees no event arg.
+cl_event* event_for(const char* label);
+
+// Drain all captured events: read profiling info, accumulate, release.
+// Safe to call multiple times — drains whatever is pending. The next
+// process_pending() picks up new events captured since.
+void process_pending();
+
+// Print the per-label summary to stderr (sorted by total time desc).
+// Implicitly calls process_pending() first so any tail events are counted.
+void dump_summary();
+
+// Reset all accumulated state. Useful between prefill and decode if you want
+// per-phase numbers; we don't do that today (single combined dump).
+void reset();
+
+}  // namespace KernelProfiler

--- a/src/models/openelm-270m/src/layers/attention.cpp
+++ b/src/models/openelm-270m/src/layers/attention.cpp
@@ -8,6 +8,7 @@
 #include "layers/attention.h"
 
 #include "debug_utils.h"
+#include "kernel_profiler.h"
 #include "layers/layer_norm.h"
 #include "model_config.h"
 #include "opencl_context.h"
@@ -267,11 +268,34 @@ bool Attention::initialize() {
   if (!set_weights()) return false;
   if (!ensure_kv_cache()) return false;
 
+  // Step 4b: pre-build RoPE cos/sin tables to MAX_CONTEXT_LENGTH so the
+  // per-decode-step regrowth + host-side trig recompute never fires in the
+  // hot path. ensure_rope_tables() is idempotent on cap, so subsequent
+  // forward() calls with smaller seq_k just no-op past this.
+  if (!ensure_rope_tables(MODEL_CONFIG::MAX_CONTEXT_LENGTH)) return false;
+
   return true;
 }
 
 cl_mem Attention::forward(cl_command_queue queue, cl_mem input, int seq_q, int start_pos) {
   return forward(queue, input, /*cos=*/nullptr, /*sin=*/nullptr, seq_q, start_pos);
+}
+
+cl_mem Attention::forward_with_residual(cl_command_queue queue,
+                                        cl_mem input,
+                                        int seq_q,
+                                        int start_pos,
+                                        cl_mem residual_inout) {
+  // Step 5: route through forward(...) but signal radd by leaving an
+  // out-of-band hint via thread_local storage — keeps the existing
+  // forward() body the canonical implementation and avoids duplicating it.
+  // Implementation: stash residual_inout in a member, run forward(), then
+  // clear. Simpler than thread_local; not thread-safe but the inference
+  // path is single-threaded by construction.
+  pending_residual_inout_ = residual_inout;
+  cl_mem result = forward(queue, input, /*cos=*/nullptr, /*sin=*/nullptr, seq_q, start_pos);
+  pending_residual_inout_ = nullptr;
+  return result;
 }
 
 cl_mem Attention::forward(cl_command_queue queue, cl_mem input, cl_mem cos, cl_mem sin, int seq_q, int start_pos) {
@@ -336,18 +360,20 @@ cl_mem Attention::forward(cl_command_queue queue, cl_mem input, cl_mem cos, cl_m
       NNOPT_ERROR_FMT("Attention[%d]: normalize_qk_projections but missing q_norm/k_norm weights", layer_idx_);
       return nullptr;
     }
-    cl_mem qn = rmsnorm_forward(cl_ctx_, queue, buf_q_, q_w, /*rows=*/seq_q * QH, /*cols=*/D, MODEL_CONFIG::NORM_EPS);
-    if (!qn) { NNOPT_ERROR_FMT("Attention[%d]: q rmsnorm_forward failed", layer_idx_); return nullptr; }
-    cl_mem kn = rmsnorm_forward(cl_ctx_, queue, buf_k_, k_w, /*rows=*/seq_q * KVH, /*cols=*/D, MODEL_CONFIG::NORM_EPS);
-    if (!kn) { NNOPT_ERROR_FMT("Attention[%d]: k rmsnorm_forward failed", layer_idx_); clReleaseMemObject(qn); return nullptr; }
-    // Copy into the persistent _qn/_kn buffers, release the rmsnorm allocations
-    err = clEnqueueCopyBuffer(queue, qn, buf_qn_, 0, 0, (size_t)seq_q * Q_DIM * sizeof(nnopt_storage_t), 0, nullptr, nullptr);
-    if (err == CL_SUCCESS)
-      err = clEnqueueCopyBuffer(queue, kn, buf_kn_, 0, 0, (size_t)seq_q * KV_DIM * sizeof(nnopt_storage_t), 0, nullptr, nullptr);
+    // Step 7-lite: write rmsnorm output directly into the persistent
+    // buf_qn_/buf_kn_ — eliminates the per-layer per-token alloc + copy +
+    // release round-trips (4 driver round-trips × 16 layers = 64/token).
+    if (!rmsnorm_forward_into(cl_ctx_, queue, buf_q_, q_w, buf_qn_,
+                              /*rows=*/seq_q * QH, /*cols=*/D, MODEL_CONFIG::NORM_EPS)) {
+      NNOPT_ERROR_FMT("Attention[%d]: q rmsnorm_forward_into failed", layer_idx_);
+      return nullptr;
+    }
+    if (!rmsnorm_forward_into(cl_ctx_, queue, buf_k_, k_w, buf_kn_,
+                              /*rows=*/seq_q * KVH, /*cols=*/D, MODEL_CONFIG::NORM_EPS)) {
+      NNOPT_ERROR_FMT("Attention[%d]: k rmsnorm_forward_into failed", layer_idx_);
+      return nullptr;
+    }
     NNOPT_DEBUG_SYNC(queue);
-    clReleaseMemObject(qn);
-    clReleaseMemObject(kn);
-    if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("Attention[%d]: copy qn/kn into persistent bufs failed (%d)", layer_idx_, (int)err); return nullptr; }
     q_for_rope = buf_qn_;
     k_for_rope = buf_kn_;
     if (layer_idx_ == 0) {
@@ -384,7 +410,8 @@ cl_mem Attention::forward(cl_command_queue queue, cl_mem input, cl_mem cos, cl_m
   {
     const int half_dim = D / 2;
     const size_t gws = (size_t)(seq_q * QH * half_dim + seq_q * KVH * half_dim);
-    err = clEnqueueNDRangeKernel(queue, rope_kernel_, 1, nullptr, &gws, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("rope_apply_qk");
+    err = clEnqueueNDRangeKernel(queue, rope_kernel_, 1, nullptr, &gws, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("rope dispatch failed: %d", (int)err); return nullptr; }
     NNOPT_DEBUG_SYNC(queue);
   }
@@ -419,7 +446,8 @@ cl_mem Attention::forward(cl_command_queue queue, cl_mem input, cl_mem cos, cl_m
   }
   {
     size_t gws_s[3] = {(size_t)QH, (size_t)seq_q, (size_t)seq_k};
-    err = clEnqueueNDRangeKernel(queue, scores_kernel_, 3, nullptr, gws_s, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("gqa_attn_scores");
+    err = clEnqueueNDRangeKernel(queue, scores_kernel_, 3, nullptr, gws_s, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("scores dispatch failed: %d", (int)err); return nullptr; }
     NNOPT_DEBUG_SYNC(queue);
   }
@@ -434,7 +462,8 @@ cl_mem Attention::forward(cl_command_queue queue, cl_mem input, cl_mem cos, cl_m
       return nullptr;
     }
     size_t gws = (size_t)total_rows;
-    err = clEnqueueNDRangeKernel(queue, softmax_kernel_, 1, nullptr, &gws, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("gqa_softmax");
+    err = clEnqueueNDRangeKernel(queue, softmax_kernel_, 1, nullptr, &gws, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("softmax dispatch failed: %d", (int)err); return nullptr; }
     NNOPT_DEBUG_SYNC(queue);
   }
@@ -456,7 +485,8 @@ cl_mem Attention::forward(cl_command_queue queue, cl_mem input, cl_mem cos, cl_m
   }
   {
     size_t gws_o[3] = {(size_t)QH, (size_t)seq_q, (size_t)(D / 4)};
-    err = clEnqueueNDRangeKernel(queue, out_kernel_, 3, nullptr, gws_o, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("gqa_attn_out");
+    err = clEnqueueNDRangeKernel(queue, out_kernel_, 3, nullptr, gws_o, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("attn_out dispatch failed: %d", (int)err); return nullptr; }
     NNOPT_DEBUG_SYNC(queue);
   }
@@ -465,7 +495,19 @@ cl_mem Attention::forward(cl_command_queue queue, cl_mem input, cl_mem cos, cl_m
     NNOPT_LAYER_CHECK("block0_sub_attn_out_proj_in", queue, buf_ctx_out_, (size_t)seq_q * (size_t)Q_DIM);
   }
 
-  // out_proj(ctx_out) — writes directly into the borrowed-handle output buffer.
+  // out_proj(ctx_out). When pending_residual_inout_ is set (Step 5), try the
+  // fused-radd path: residual += out_proj(ctx_out). Falls back to the
+  // un-fused write into buf_proj_ if the radd kernel is ineligible.
+  if (pending_residual_inout_ != nullptr) {
+    if (pytorch_linear_radd(queue, seq_q, H, Q_DIM, buf_ctx_out_, wo_, pending_residual_inout_)) {
+      if (layer_idx_ == 0) {
+        NNOPT_LAYER_CHECK("block0_sub_attn_out_proj_out", queue, pending_residual_inout_, (size_t)seq_q * (size_t)H);
+      }
+      return pending_residual_inout_;
+    }
+    // Fallthrough — radd ineligible (M>1 etc.). The caller must do the
+    // explicit residual add against buf_proj_.
+  }
   if (!pytorch_linear(queue, seq_q, H, Q_DIM, buf_ctx_out_, wo_, buf_proj_)) {
     NNOPT_ERROR_FMT("out_proj gemm failed at layer %d", layer_idx_);
     return nullptr;

--- a/src/models/openelm-270m/src/layers/attention.h
+++ b/src/models/openelm-270m/src/layers/attention.h
@@ -51,6 +51,20 @@ public:
                    int seq_q,
                    int start_pos);
 
+    // Step 5: forward with FUSED RESIDUAL ADD at out_proj.
+    // residual_inout is the residual-stream buffer; on success the layer
+    // writes residual_inout[i] += out_proj_output[i] in a single GEMV launch
+    // (gemv_m1_no4_radd) and returns residual_inout. If the fused path is
+    // not eligible (M>1 or shape mismatch), falls back to the un-fused path
+    // and the caller is responsible for the explicit element_add — but at
+    // M=1 every OpenELM layer is eligible so this is the always-on decode path.
+    // Returns BORROWED handle (residual_inout when fused, buf_proj_ when not).
+    cl_mem forward_with_residual(cl_command_queue queue,
+                                 cl_mem input,
+                                 int seq_q,
+                                 int start_pos,
+                                 cl_mem residual_inout);
+
 private:
     bool ensure_rope_tables(int seq_len);
     bool ensure_kv_cache();   // Allocates k_cache_/v_cache_ once, on first forward.
@@ -113,6 +127,11 @@ private:
     cl_mem buf_scores_   = nullptr;   // [QH, seq_q, seq_k]
     cl_mem buf_ctx_out_  = nullptr;   // [seq_q, Q_DIM]
     cl_mem buf_proj_     = nullptr;   // [seq_q, HIDDEN]   (returned to caller)
+    // Step 5: out-of-band signal from forward_with_residual() to forward(...).
+    // When non-null, the out_proj GEMV uses pytorch_linear_radd to fuse the
+    // residual add into the same launch and returns this buffer instead of
+    // buf_proj_. Set/cleared around the forward() call; not thread-safe.
+    cl_mem pending_residual_inout_ = nullptr;
     size_t buf_qkv_cap_      = 0;
     size_t buf_q_cap_        = 0;
     size_t buf_k_cap_        = 0;

--- a/src/models/openelm-270m/src/layers/embedding.cpp
+++ b/src/models/openelm-270m/src/layers/embedding.cpp
@@ -3,6 +3,7 @@
 #include "layers/embedding.h"
 
 #include "debug_utils.h"
+#include "kernel_profiler.h"
 #include "model_config.h"
 #include "utils.h"
 
@@ -20,6 +21,38 @@ Embedding::~Embedding() {
     clReleaseProgram(program_);
     program_ = nullptr;
   }
+  if (token_ids_buf_) {
+    clReleaseMemObject(token_ids_buf_);
+    token_ids_buf_ = nullptr;
+  }
+  if (zero_wpe_) {
+    clReleaseMemObject(zero_wpe_);
+    zero_wpe_ = nullptr;
+  }
+  if (out_buf_) {
+    clReleaseMemObject(out_buf_);
+    out_buf_ = nullptr;
+  }
+}
+
+// Step Z: ensure the persistent output buffer can hold seq_len rows.
+static inline bool ensure_emb_out_buf_(cl_context ctx,
+                                       cl_mem* buf,
+                                       size_t* cap_bytes,
+                                       int seq_len) {
+  const size_t needed = (size_t)seq_len * (size_t)MODEL_CONFIG::HIDDEN_SIZE * sizeof(nnopt_storage_t);
+  if (*cap_bytes >= needed && *buf) return true;
+  if (*buf) clReleaseMemObject(*buf);
+  cl_int err = CL_SUCCESS;
+  *buf = clCreateBuffer(ctx, CL_MEM_READ_WRITE, needed, nullptr, &err);
+  if (err != CL_SUCCESS || !*buf) {
+    NNOPT_ERROR_FMT("Embedding: persistent out_buf alloc failed (%d)", (int)err);
+    *buf = nullptr;
+    *cap_bytes = 0;
+    return false;
+  }
+  *cap_bytes = needed;
+  return true;
 }
 
 bool Embedding::initialize() {
@@ -52,6 +85,87 @@ bool Embedding::initialize() {
   return true;
 }
 
+cl_mem Embedding::forward_from_device_token(cl_command_queue queue,
+                                            cl_mem token_ids_dev,
+                                            size_t dev_offset_bytes,
+                                            int start_pos) {
+  // Mirrors forward() but skips the host→device upload by copying a single
+  // int32 from `token_ids_dev` into the persistent token_ids_buf_, then
+  // dispatching the standard embedding kernel.
+  if (!kernel_ || !token_emb_) {
+    NNOPT_ERROR("Embedding::forward_from_device_token before initialize");
+    return nullptr;
+  }
+  cl_int err = CL_SUCCESS;
+  cl_context ctx = cl_ctx_.context();
+  const size_t needed_ids_bytes = sizeof(int);
+  if (token_ids_buf_cap_bytes_ < needed_ids_bytes) {
+    if (token_ids_buf_) clReleaseMemObject(token_ids_buf_);
+    token_ids_buf_ = clCreateBuffer(ctx, CL_MEM_READ_WRITE, needed_ids_bytes, nullptr, &err);
+    if (err != CL_SUCCESS || !token_ids_buf_) {
+      NNOPT_ERROR_FMT("Embedding: alloc chained token_ids buffer failed (%d)", (int)err);
+      token_ids_buf_ = nullptr;
+      token_ids_buf_cap_bytes_ = 0;
+      return nullptr;
+    }
+    token_ids_buf_cap_bytes_ = needed_ids_bytes;
+  }
+  err = clEnqueueCopyBuffer(queue, token_ids_dev, token_ids_buf_,
+                            dev_offset_bytes, 0, sizeof(int), 0, nullptr, nullptr);
+  if (err != CL_SUCCESS) {
+    NNOPT_ERROR_FMT("Embedding: chained copy from argmax_result failed (%d)", (int)err);
+    return nullptr;
+  }
+
+  // Step Z: persistent output buffer — chained forward returns BORROWED.
+  if (!ensure_emb_out_buf_(ctx, &out_buf_, &out_buf_cap_bytes_, /*seq_len=*/1)) return nullptr;
+  cl_mem out = out_buf_;
+
+  cl_mem wpe = pos_emb_;
+  if (!wpe) {
+    const size_t needed_wpe_bytes =
+        (size_t)MODEL_CONFIG::MAX_CONTEXT_LENGTH * (size_t)MODEL_CONFIG::HIDDEN_SIZE * sizeof(nnopt_storage_t);
+    if (zero_wpe_cap_bytes_ < needed_wpe_bytes) {
+      if (zero_wpe_) clReleaseMemObject(zero_wpe_);
+      zero_wpe_ = clCreateBuffer(ctx, CL_MEM_READ_WRITE, needed_wpe_bytes, nullptr, &err);
+      if (err != CL_SUCCESS || !zero_wpe_) {
+        NNOPT_ERROR_FMT("Embedding: chained zero_wpe alloc failed (%d)", (int)err);
+        zero_wpe_ = nullptr;
+        zero_wpe_cap_bytes_ = 0;
+        return nullptr;
+      }
+      const nnopt_storage_t zero = nnopt_storage_t{};
+      err = clEnqueueFillBuffer(queue, zero_wpe_, &zero, sizeof(nnopt_storage_t), 0, needed_wpe_bytes,
+                                0, nullptr, nullptr);
+      if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("Embedding: chained zero_wpe fill failed (%d)", (int)err);
+        return nullptr;
+      }
+      zero_wpe_cap_bytes_ = needed_wpe_bytes;
+    }
+    wpe = zero_wpe_;
+  }
+
+  const int hidden = MODEL_CONFIG::HIDDEN_SIZE;
+  if (clSetKernelArg(kernel_, 0, sizeof(cl_mem), &token_ids_buf_) != CL_SUCCESS ||
+      clSetKernelArg(kernel_, 1, sizeof(cl_mem), &token_emb_) != CL_SUCCESS ||
+      clSetKernelArg(kernel_, 2, sizeof(cl_mem), &wpe) != CL_SUCCESS ||
+      clSetKernelArg(kernel_, 3, sizeof(cl_mem), &out) != CL_SUCCESS ||
+      clSetKernelArg(kernel_, 4, sizeof(int), &hidden) != CL_SUCCESS ||
+      clSetKernelArg(kernel_, 5, sizeof(int), &start_pos) != CL_SUCCESS) {
+    NNOPT_ERROR("Embedding: chained setKernelArg failed");
+    return nullptr;
+  }
+  const size_t gws[1] = {(size_t)1};
+  cl_event* evt = KernelProfiler::event_for("embedding_chained");
+  err = clEnqueueNDRangeKernel(queue, kernel_, 1, nullptr, gws, nullptr, 0, nullptr, evt);
+  if (err != CL_SUCCESS) {
+    NNOPT_ERROR_FMT("Embedding: chained enqueue failed (%d)", (int)err);
+    return nullptr;
+  }
+  return out;  // BORROWED.
+}
+
 cl_mem Embedding::forward(cl_command_queue queue, const int* token_ids, int seq_len, int start_pos) {
   if (!kernel_ || !token_emb_) {
     NNOPT_ERROR("Embedding::forward called before initialize");
@@ -61,61 +175,65 @@ cl_mem Embedding::forward(cl_command_queue queue, const int* token_ids, int seq_
   cl_int err = CL_SUCCESS;
   cl_context ctx = cl_ctx_.context();
 
-  // Upload token IDs
-  cl_mem token_ids_buf = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
-                                       (size_t)seq_len * sizeof(int), (void*)token_ids, &err);
-  if (err != CL_SUCCESS || !token_ids_buf) {
-    NNOPT_ERROR_FMT("Embedding: failed to create token_ids buffer (%d)", (int)err);
+  // Step 4a: persistent token-IDs upload buffer. Grow on demand; reuse the
+  // capacity sticky-style. Saves ~50 µs of clCreateBuffer/clReleaseMemObject
+  // overhead per decode token.
+  const size_t needed_ids_bytes = (size_t)seq_len * sizeof(int);
+  if (token_ids_buf_cap_bytes_ < needed_ids_bytes) {
+    if (token_ids_buf_) clReleaseMemObject(token_ids_buf_);
+    token_ids_buf_ = clCreateBuffer(ctx, CL_MEM_READ_ONLY, needed_ids_bytes, nullptr, &err);
+    if (err != CL_SUCCESS || !token_ids_buf_) {
+      NNOPT_ERROR_FMT("Embedding: failed to grow token_ids buffer (%d)", (int)err);
+      token_ids_buf_ = nullptr;
+      token_ids_buf_cap_bytes_ = 0;
+      return nullptr;
+    }
+    token_ids_buf_cap_bytes_ = needed_ids_bytes;
+  }
+  err = clEnqueueWriteBuffer(queue, token_ids_buf_, CL_FALSE, 0, needed_ids_bytes,
+                             (const void*)token_ids, 0, nullptr, nullptr);
+  if (err != CL_SUCCESS) {
+    NNOPT_ERROR_FMT("Embedding: clEnqueueWriteBuffer token_ids failed (%d)", (int)err);
     return nullptr;
   }
 
-  // Output: [seq_len, hidden]
-  const size_t out_elems = (size_t)seq_len * (size_t)MODEL_CONFIG::HIDDEN_SIZE;
-  const size_t out_bytes = out_elems * sizeof(nnopt_storage_t);
-  cl_mem out = clCreateBuffer(ctx, CL_MEM_READ_WRITE, out_bytes, nullptr, &err);
-  if (err != CL_SUCCESS || !out) {
-    NNOPT_ERROR_FMT("Embedding: failed to create output buffer (%d)", (int)err);
-    clReleaseMemObject(token_ids_buf);
-    return nullptr;
-  }
+  // Step Z: persistent output buffer. forward() returns this BORROWED.
+  if (!ensure_emb_out_buf_(ctx, &out_buf_, &out_buf_cap_bytes_, seq_len)) return nullptr;
+  cl_mem out = out_buf_;
 
   // For RoPE-only models, we want tok_emb + 0. The kernel currently expects a
-  // wpe pointer. If pos_emb_ is null, we allocate a temporary zero buffer.
+  // wpe pointer. If pos_emb_ is null, we use a persistent zero buffer sized to
+  // MAX_CONTEXT_LENGTH × HIDDEN_SIZE (allocated once, zero-filled lazily).
   cl_mem wpe = pos_emb_;
-  cl_mem tmp_zero = nullptr;
   if (!wpe) {
-    // One row of zeros is enough because the kernel indexes wpe by abs_pos.
-    // But to keep semantics safe, allocate MAX_SEQ_LEN rows (still small-ish)
-    // is too big. Instead, allocate seq_len rows and clamp start_pos to 0.
-    // Since OpenELM has no wpe in PyTorch, the additive term must be zero for
-    // all positions; using a seq_len table and forcing start_pos=0 preserves that.
-    const size_t wpe_elems = out_elems;
-    const size_t wpe_bytes = wpe_elems * sizeof(nnopt_storage_t);
-    tmp_zero = clCreateBuffer(ctx, CL_MEM_READ_WRITE, wpe_bytes, nullptr, &err);
-    if (err != CL_SUCCESS || !tmp_zero) {
-      NNOPT_ERROR_FMT("Embedding: failed to create tmp_zero wpe buffer (%d)", (int)err);
-      clReleaseMemObject(token_ids_buf);
-      clReleaseMemObject(out);
-      return nullptr;
+    const size_t needed_wpe_bytes =
+        (size_t)MODEL_CONFIG::MAX_CONTEXT_LENGTH * (size_t)MODEL_CONFIG::HIDDEN_SIZE * sizeof(nnopt_storage_t);
+    if (zero_wpe_cap_bytes_ < needed_wpe_bytes) {
+      if (zero_wpe_) clReleaseMemObject(zero_wpe_);
+      zero_wpe_ = clCreateBuffer(ctx, CL_MEM_READ_WRITE, needed_wpe_bytes, nullptr, &err);
+      if (err != CL_SUCCESS || !zero_wpe_) {
+        NNOPT_ERROR_FMT("Embedding: failed to allocate zero_wpe buffer (%d)", (int)err);
+        zero_wpe_ = nullptr;
+        zero_wpe_cap_bytes_ = 0;
+        clReleaseMemObject(out);
+        return nullptr;
+      }
+      const nnopt_storage_t zero = nnopt_storage_t{};
+      err = clEnqueueFillBuffer(queue, zero_wpe_, &zero, sizeof(nnopt_storage_t), 0, needed_wpe_bytes,
+                                0, nullptr, nullptr);
+      if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("Embedding: clEnqueueFillBuffer zero_wpe failed (%d)", (int)err);
+        return nullptr;
+      }
+      zero_wpe_cap_bytes_ = needed_wpe_bytes;
     }
-
-    // Fill with 0
-    const nnopt_storage_t zero = nnopt_storage_t{};
-    err = clEnqueueFillBuffer(queue, tmp_zero, &zero, sizeof(nnopt_storage_t), 0, wpe_bytes, 0, nullptr, nullptr);
-    if (err != CL_SUCCESS) {
-      NNOPT_ERROR_FMT("Embedding: clEnqueueFillBuffer failed (%d)", (int)err);
-      clReleaseMemObject(tmp_zero);
-      clReleaseMemObject(token_ids_buf);
-      clReleaseMemObject(out);
-      return nullptr;
-    }
-    wpe = tmp_zero;
-    start_pos = 0;
+    wpe = zero_wpe_;
+    // No-op: start_pos still indexes into a fully-zero table.
   }
 
   const int hidden = MODEL_CONFIG::HIDDEN_SIZE;
 
-  err = clSetKernelArg(kernel_, 0, sizeof(cl_mem), &token_ids_buf);
+  err = clSetKernelArg(kernel_, 0, sizeof(cl_mem), &token_ids_buf_);
   if (err != CL_SUCCESS) {
     NNOPT_ERROR_FMT("Embedding: setArg token_ids failed (%d)", (int)err);
     goto cleanup;
@@ -148,23 +266,19 @@ cl_mem Embedding::forward(cl_command_queue queue, const int* token_ids, int seq_
 
   {
     const size_t gws[1] = {(size_t)seq_len};
-    err = clEnqueueNDRangeKernel(queue, kernel_, 1, nullptr, gws, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("embedding");
+    err = clEnqueueNDRangeKernel(queue, kernel_, 1, nullptr, gws, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) {
       NNOPT_ERROR_FMT("Embedding: enqueue failed (%d)", (int)err);
       goto cleanup;
     }
   }
 
-  // Keep sync conservative for now (debug-first).
-  clFinish(queue);
+  NNOPT_DEBUG_SYNC(queue);
 
 cleanup:
-  if (tmp_zero) clReleaseMemObject(tmp_zero);
-  clReleaseMemObject(token_ids_buf);
-
   if (err != CL_SUCCESS) {
-    clReleaseMemObject(out);
     return nullptr;
   }
-  return out;
+  return out;  // BORROWED — owned by *this until next call.
 }

--- a/src/models/openelm-270m/src/layers/embedding.h
+++ b/src/models/openelm-270m/src/layers/embedding.h
@@ -18,6 +18,16 @@ public:
   // start_pos: absolute position offset (0 for prefill, prompt_len+step for decode).
   cl_mem forward(cl_command_queue queue, const int* token_ids, int seq_len, int start_pos);
 
+  // Step 9: chained-decode variant. Embedding reads its single token id from
+  // an existing GPU-side int32 buffer (`token_ids_dev`) at byte offset
+  // `dev_offset_bytes`. Used to plumb the previous step's argmax_result_
+  // directly into this step's embedding without a host roundtrip.
+  // Always seq_len==1 at decode (caller guarantees).
+  cl_mem forward_from_device_token(cl_command_queue queue,
+                                   cl_mem token_ids_dev,
+                                   size_t dev_offset_bytes,
+                                   int start_pos);
+
 private:
   OpenCLContext& cl_ctx_;
   Weights& weights_;
@@ -27,4 +37,21 @@ private:
 
   cl_mem token_emb_ = nullptr; // transformer.token_embeddings.weight
   cl_mem pos_emb_ = nullptr;   // optional; OpenELM is RoPE-only, so nullptr
+
+  // Persistent token-IDs upload buffer (Step 4a). Avoids the per-decode-token
+  // clCreateBuffer + clReleaseMemObject round-trip; we write into a sticky
+  // buffer instead. Capacity grows but never shrinks.
+  cl_mem token_ids_buf_ = nullptr;
+  size_t token_ids_buf_cap_bytes_ = 0;
+
+  // Persistent zero-padded wpe buffer (Step 4 nearby fix). OpenELM has no
+  // learned positional embeddings, so the embedding kernel gets zeros here.
+  // Sized once to MAX_CONTEXT_LENGTH × HIDDEN_SIZE; reused every call.
+  cl_mem zero_wpe_ = nullptr;
+  size_t zero_wpe_cap_bytes_ = 0;
+
+  // Step Z: persistent output buffer. forward() returns this BORROWED, so the
+  // caller does not allocate or release. Saves 1 alloc + 1 release per token.
+  cl_mem out_buf_ = nullptr;
+  size_t out_buf_cap_bytes_ = 0;
 };

--- a/src/models/openelm-270m/src/layers/layer_norm.cpp
+++ b/src/models/openelm-270m/src/layers/layer_norm.cpp
@@ -3,6 +3,7 @@
 #include "layers/layer_norm.h"
 
 #include "debug_utils.h"
+#include "kernel_profiler.h"
 #include "model_config.h"
 #include "utils.h"
 
@@ -11,7 +12,9 @@
 LayerNorm::LayerNorm(OpenCLContext& cl_ctx, Weights& weights, int layer_idx, const std::string& weight_key)
     : cl_ctx_(cl_ctx), weights_(weights), layer_idx_(layer_idx), weight_key_(weight_key) {}
 
-LayerNorm::~LayerNorm() {}
+LayerNorm::~LayerNorm() {
+  if (out_buf_) clReleaseMemObject(out_buf_);
+}
 
 bool LayerNorm::initialize() {
   weight_ = weights_.get_buffer(weight_key_);
@@ -27,13 +30,51 @@ cl_mem LayerNorm::forward(cl_command_queue queue, cl_mem input, int seq_len) {
     NNOPT_ERROR_FMT("LayerNorm[%d]: forward before initialize", layer_idx_);
     return nullptr;
   }
-  return rmsnorm_forward(cl_ctx_, queue, input, weight_, seq_len, MODEL_CONFIG::HIDDEN_SIZE, MODEL_CONFIG::NORM_EPS);
+  const size_t needed = (size_t)seq_len * (size_t)MODEL_CONFIG::HIDDEN_SIZE * sizeof(nnopt_storage_t);
+  if (out_buf_cap_bytes_ < needed) {
+    if (out_buf_) clReleaseMemObject(out_buf_);
+    cl_int err = CL_SUCCESS;
+    out_buf_ = clCreateBuffer(cl_ctx_.context(), CL_MEM_READ_WRITE, needed, nullptr, &err);
+    if (err != CL_SUCCESS || !out_buf_) {
+      NNOPT_ERROR_FMT("LayerNorm[%d]: persistent out_buf alloc failed (%d)", layer_idx_, (int)err);
+      out_buf_ = nullptr;
+      out_buf_cap_bytes_ = 0;
+      return nullptr;
+    }
+    out_buf_cap_bytes_ = needed;
+  }
+  if (!rmsnorm_forward_into(cl_ctx_, queue, input, weight_, out_buf_,
+                            seq_len, MODEL_CONFIG::HIDDEN_SIZE, MODEL_CONFIG::NORM_EPS)) {
+    return nullptr;
+  }
+  return out_buf_;
 }
 
 // rmsnorm.cl declares __attribute__((reqd_work_group_size(64,1,1))) — caller
 // MUST pass lws=64 or the runtime fails CL_INVALID_WORK_GROUP_SIZE silently
 // and produces orthogonal output (cos≈0 in SxS).
 static constexpr size_t RMSNORM_WG = 64;
+
+// Internal: dispatch the rmsnorm kernel into a given output buffer.
+static bool rmsnorm_dispatch_(OpenCLContext& cl_ctx,
+                              cl_command_queue queue,
+                              cl_mem input,
+                              cl_mem weight,
+                              cl_mem output,
+                              int rows,
+                              int cols,
+                              float eps);
+
+bool rmsnorm_forward_into(OpenCLContext& cl_ctx,
+                          cl_command_queue queue,
+                          cl_mem input,
+                          cl_mem weight,
+                          cl_mem output,
+                          int rows,
+                          int cols,
+                          float eps) {
+  return rmsnorm_dispatch_(cl_ctx, queue, input, weight, output, rows, cols, eps);
+}
 
 cl_mem rmsnorm_forward(OpenCLContext& cl_ctx,
                        cl_command_queue queue,
@@ -42,25 +83,6 @@ cl_mem rmsnorm_forward(OpenCLContext& cl_ctx,
                        int rows,
                        int cols,
                        float eps) {
-  // Lazy-build the rmsnorm program + kernel ONCE per process. clCreateKernel
-  // is cheap but not free; this matches the kernel-cache pattern used by
-  // utils.cpp::element_add_inplace for hot helpers.
-  static cl_program s_prog = nullptr;
-  static cl_kernel s_kernel = nullptr;
-  if (!s_kernel) {
-    s_prog = cl_ctx.build_program_from_file("kernels/rmsnorm.cl");
-    if (!s_prog) {
-      NNOPT_ERROR("rmsnorm_forward: failed to build kernels/rmsnorm.cl");
-      return nullptr;
-    }
-    cl_int kerr = CL_SUCCESS;
-    s_kernel = clCreateKernel(s_prog, "rmsnorm_forward", &kerr);
-    if (kerr != CL_SUCCESS || !s_kernel) {
-      NNOPT_ERROR_FMT("rmsnorm_forward: clCreateKernel failed (%d)", (int)kerr);
-      return nullptr;
-    }
-  }
-
   cl_int err = CL_SUCCESS;
   cl_mem out = clCreateBuffer(cl_ctx.context(), CL_MEM_READ_WRITE,
                               (size_t)rows * (size_t)cols * sizeof(nnopt_storage_t), nullptr, &err);
@@ -68,27 +90,57 @@ cl_mem rmsnorm_forward(OpenCLContext& cl_ctx,
     NNOPT_ERROR_FMT("rmsnorm_forward: clCreateBuffer out failed (%d)", (int)err);
     return nullptr;
   }
+  if (!rmsnorm_dispatch_(cl_ctx, queue, input, weight, out, rows, cols, eps)) {
+    clReleaseMemObject(out);
+    return nullptr;
+  }
+  return out;
+}
 
+static bool rmsnorm_dispatch_(OpenCLContext& cl_ctx,
+                              cl_command_queue queue,
+                              cl_mem input,
+                              cl_mem weight,
+                              cl_mem output,
+                              int rows,
+                              int cols,
+                              float eps) {
+  static cl_program s_prog = nullptr;
+  static cl_kernel s_kernel = nullptr;
+  if (!s_kernel) {
+    s_prog = cl_ctx.build_program_from_file("kernels/rmsnorm.cl");
+    if (!s_prog) {
+      NNOPT_ERROR("rmsnorm_forward: failed to build kernels/rmsnorm.cl");
+      return false;
+    }
+    cl_int kerr = CL_SUCCESS;
+    s_kernel = clCreateKernel(s_prog, "rmsnorm_forward", &kerr);
+    if (kerr != CL_SUCCESS || !s_kernel) {
+      NNOPT_ERROR_FMT("rmsnorm_forward: clCreateKernel failed (%d)", (int)kerr);
+      return false;
+    }
+  }
+
+  cl_int err = CL_SUCCESS;
   err = clSetKernelArg(s_kernel, 0, sizeof(cl_mem), &input);
   if (err == CL_SUCCESS) err = clSetKernelArg(s_kernel, 1, sizeof(cl_mem), &weight);
-  if (err == CL_SUCCESS) err = clSetKernelArg(s_kernel, 2, sizeof(cl_mem), &out);
+  if (err == CL_SUCCESS) err = clSetKernelArg(s_kernel, 2, sizeof(cl_mem), &output);
   if (err == CL_SUCCESS) err = clSetKernelArg(s_kernel, 3, sizeof(int), &rows);
   if (err == CL_SUCCESS) err = clSetKernelArg(s_kernel, 4, sizeof(int), &cols);
   if (err == CL_SUCCESS) err = clSetKernelArg(s_kernel, 5, sizeof(float), &eps);
   if (err != CL_SUCCESS) {
     NNOPT_ERROR_FMT("rmsnorm_forward: clSetKernelArg failed (%d)", (int)err);
-    clReleaseMemObject(out);
-    return nullptr;
+    return false;
   }
 
   const size_t gws = (size_t)rows * RMSNORM_WG;
   const size_t lws = RMSNORM_WG;
-  err = clEnqueueNDRangeKernel(queue, s_kernel, 1, nullptr, &gws, &lws, 0, nullptr, nullptr);
+  cl_event* evt = KernelProfiler::event_for("rmsnorm");
+  err = clEnqueueNDRangeKernel(queue, s_kernel, 1, nullptr, &gws, &lws, 0, nullptr, evt);
   if (err != CL_SUCCESS) {
     NNOPT_ERROR_FMT("rmsnorm_forward: clEnqueueNDRangeKernel failed (%d)", (int)err);
-    clReleaseMemObject(out);
-    return nullptr;
+    return false;
   }
   NNOPT_DEBUG_SYNC(queue);
-  return out;
+  return true;
 }

--- a/src/models/openelm-270m/src/layers/layer_norm.h
+++ b/src/models/openelm-270m/src/layers/layer_norm.h
@@ -18,7 +18,10 @@ class LayerNorm {
   bool initialize();
 
   // input: [seq_len, hidden] storage_t
-  // returns: NEW [seq_len, hidden] cl_mem (caller releases). nullptr on failure.
+  // returns: BORROWED [seq_len, hidden] cl_mem owned by *this. Valid until
+  // the next call. Caller MUST NOT release. Step Z: replaces the per-call
+  // alloc that was here before — saves ~30 µs of driver round-trip per
+  // norm dispatch (33 norms/token at decode = ~1 ms/token).
   cl_mem forward(cl_command_queue queue, cl_mem input, int seq_len);
 
  private:
@@ -27,6 +30,10 @@ class LayerNorm {
   int layer_idx_;
   std::string weight_key_;
   cl_mem weight_ = nullptr;
+
+  // Persistent output buffer. Grown on demand by forward(); released in dtor.
+  cl_mem out_buf_ = nullptr;
+  size_t out_buf_cap_bytes_ = 0;
 };
 
 // Free helper used by Attention (optional q_norm/k_norm) and Mlp (ffn_norm).
@@ -39,3 +46,17 @@ cl_mem rmsnorm_forward(OpenCLContext& cl_ctx,
                        int rows,
                        int cols,
                        float eps);
+
+// Variant that writes into a caller-provided output buffer. No allocation,
+// no return-buffer ownership transfer. Used at attn.q_norm and attn.k_norm
+// where the output is immediately copied into a persistent buf_qn_/buf_kn_;
+// here we eliminate both the alloc and the copy by writing straight into
+// the destination.
+bool rmsnorm_forward_into(OpenCLContext& cl_ctx,
+                          cl_command_queue queue,
+                          cl_mem input,
+                          cl_mem weight,
+                          cl_mem output,
+                          int rows,
+                          int cols,
+                          float eps);

--- a/src/models/openelm-270m/src/layers/mlp.cpp
+++ b/src/models/openelm-270m/src/layers/mlp.cpp
@@ -3,6 +3,7 @@
 #include "layers/mlp.h"
 
 #include "debug_utils.h"
+#include "kernel_profiler.h"
 #include "layers/layer_norm.h"
 #include "model_config.h"
 #include "utils.h"
@@ -137,7 +138,8 @@ cl_mem Mlp::forward(cl_command_queue queue, cl_mem input, int seq_len) {
   }
   {
     const size_t gws = (size_t)seq_len * (size_t)I;
-    err = clEnqueueNDRangeKernel(queue, kernel_swiglu_, 1, nullptr, &gws, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("swiglu");
+    err = clEnqueueNDRangeKernel(queue, kernel_swiglu_, 1, nullptr, &gws, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) {
       NNOPT_ERROR_FMT("Mlp[%d]: swiglu_forward launch failed (%d)", layer_idx_, (int)err);
       return nullptr;
@@ -149,7 +151,18 @@ cl_mem Mlp::forward(cl_command_queue queue, cl_mem input, int seq_len) {
     NNOPT_LAYER_CHECK("block0_sub_ffn_proj_2_in", queue, buf_gate_, (size_t)seq_len * (size_t)I);
   }
 
-  // proj_2: [M,I] x [H,I]^T -> [M,H]
+  // proj_2: [M,I] x [H,I]^T -> [M,H]. When pending_residual_inout_ is set
+  // (Step 5), try the fused-radd path: residual += proj_2(gate). Falls back
+  // to un-fused write if shape ineligible.
+  if (pending_residual_inout_ != nullptr) {
+    if (pytorch_linear_radd(queue, seq_len, H, I, buf_gate_, proj2_w_, pending_residual_inout_)) {
+      if (layer_idx_ == 0) {
+        NNOPT_LAYER_CHECK("block0_sub_ffn_proj_2_out", queue, pending_residual_inout_, (size_t)seq_len * (size_t)H);
+      }
+      return pending_residual_inout_;
+    }
+    // Fallthrough — radd ineligible.
+  }
   if (!pytorch_linear(queue, seq_len, H, I, buf_gate_, proj2_w_, buf_proj2_out_)) {
     NNOPT_ERROR_FMT("Mlp[%d]: pytorch_linear proj_2 failed", layer_idx_);
     return nullptr;
@@ -161,4 +174,14 @@ cl_mem Mlp::forward(cl_command_queue queue, cl_mem input, int seq_len) {
 
   // BORROWED handle — caller must NOT release. Owned by *this until next call.
   return buf_proj2_out_;
+}
+
+cl_mem Mlp::forward_with_residual(cl_command_queue queue,
+                                  cl_mem input,
+                                  int seq_len,
+                                  cl_mem residual_inout) {
+  pending_residual_inout_ = residual_inout;
+  cl_mem result = forward(queue, input, seq_len);
+  pending_residual_inout_ = nullptr;
+  return result;
 }

--- a/src/models/openelm-270m/src/layers/mlp.h
+++ b/src/models/openelm-270m/src/layers/mlp.h
@@ -19,6 +19,15 @@ class Mlp {
   // Caller MUST NOT release. Owned by *this.
   cl_mem forward(cl_command_queue queue, cl_mem input, int seq_len);
 
+  // Step 5: forward with FUSED RESIDUAL ADD at proj_2. residual_inout is
+  // the residual-stream buffer; on success this writes residual_inout[i] +=
+  // proj_2_output[i] in one GEMV launch and returns residual_inout. Falls
+  // back to un-fused path if shape ineligible. Caller owns residual_inout.
+  cl_mem forward_with_residual(cl_command_queue queue,
+                               cl_mem input,
+                               int seq_len,
+                               cl_mem residual_inout);
+
  private:
   bool ensure_activation_buffers_(int seq_len);
   void release_activation_buffers_();
@@ -49,4 +58,9 @@ class Mlp {
   size_t buf_proj1_out_cap_ = 0;
   size_t buf_gate_cap_      = 0;
   size_t buf_proj2_out_cap_ = 0;
+
+  // Step 5: out-of-band signal from forward_with_residual() to forward(...).
+  // When non-null, the proj_2 GEMV uses pytorch_linear_radd to fuse the
+  // residual add and returns this buffer instead of buf_proj2_out_.
+  cl_mem pending_residual_inout_ = nullptr;
 };

--- a/src/models/openelm-270m/src/main.cpp
+++ b/src/models/openelm-270m/src/main.cpp
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "debug_utils.h"
 #include "benchmark.h"
+#include "kernel_profiler.h"
 #include <iostream>
 #include <string>
 #include <cstring>
@@ -83,7 +84,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed to initialize OpenCL" << std::endl;
         return 1;
     }
-    std::cerr << "Device: " << cl_ctx.device_name() << std::endl;
+    std::cerr << "Device: " << cl_ctx.device_description() << std::endl;
     NNOPT_CHECKPOINT("OpenCL initialized");
 
     // Load tokenizer (still needed for decoding output)
@@ -265,8 +266,6 @@ int main(int argc, char* argv[]) {
 
     // Generate
     NNOPT_CHECKPOINT("starting generation");
-    Timer timer;
-    timer.start();
 
     // Prefill clock starts now — excludes tokenize (see comment block above the
     // mark_inference_start() call for the full metric contract).
@@ -306,7 +305,6 @@ int main(int argc, char* argv[]) {
         std::fflush(stdout);
     }
     bench.mark_end();
-    double elapsed = timer.elapsed_ms();
     int gen_tokens = output_ids.size() - input_ids.size();
     NNOPT_CHECKPOINT("generation complete");
 
@@ -336,13 +334,11 @@ int main(int argc, char* argv[]) {
         std::cout << std::endl;
     }
 
-    // Stats (human-readable summary — kept for backward compat with old parsers)
-    std::cerr << "Generated " << gen_tokens << " tokens in "
-              << elapsed << " ms ("
-              << (gen_tokens * 1000.0 / elapsed) << " tokens/sec)" << std::endl;
-
     // Structured baseline metrics for FinalizePort / README generation.
     bench.print_summary((int)input_ids.size(), gen_tokens);
+
+    // Per-kernel profile dump — only emits when NNOPT_KERNEL_PROFILE=1.
+    KernelProfiler::dump_summary();
 
     // Clean-exit marker — Infer treats absence of this line in stderr as
     // evidence that the binary was killed mid-run (lowmemorykiller, SIGSEGV,

--- a/src/models/openelm-270m/src/model.cpp
+++ b/src/models/openelm-270m/src/model.cpp
@@ -5,6 +5,7 @@
 #include "sampler.h"
 #include "debug_utils.h"
 #include "benchmark.h"
+#include "kernel_profiler.h"
 #include "model_config.h"
 #include "utils.h"
 #include <iostream>
@@ -23,6 +24,23 @@ Model::~Model() {
     if (argmax_kernel_)  clReleaseKernel(argmax_kernel_);
     if (argmax_program_) clReleaseProgram(argmax_program_);
     if (argmax_result_)  clReleaseMemObject(argmax_result_);
+    if (logits_buf_)     clReleaseMemObject(logits_buf_);
+}
+
+bool Model::ensure_logits_buf_(int seq_len) {
+    const size_t needed = (size_t)seq_len * (size_t)MODEL_CONFIG::VOCAB_SIZE * sizeof(nnopt_storage_t);
+    if (logits_buf_cap_bytes_ >= needed && logits_buf_) return true;
+    if (logits_buf_) clReleaseMemObject(logits_buf_);
+    cl_int err = CL_SUCCESS;
+    logits_buf_ = clCreateBuffer(cl_ctx_.context(), CL_MEM_READ_WRITE, needed, nullptr, &err);
+    if (err != CL_SUCCESS || !logits_buf_) {
+        NNOPT_ERROR_FMT("Model: persistent logits_buf_ alloc failed (%d)", (int)err);
+        logits_buf_ = nullptr;
+        logits_buf_cap_bytes_ = 0;
+        return false;
+    }
+    logits_buf_cap_bytes_ = needed;
+    return true;
 }
 
 bool Model::ensure_argmax_resources_() {
@@ -262,125 +280,116 @@ std::vector<float> Model::forward(const std::vector<int32_t>& input_ids, int sta
         return {};
     }
 
-    // Transformer blocks
+    // Transformer blocks. Step Z: pre/post norm outputs are BORROWED from
+    // the LayerNorm instance. Track whether `hidden` is the embedding's
+    // persistent buffer (pristine == true) or a fallback-allocated buffer.
+    bool hidden_is_pristine = true;
     for (int i = 0; i < MODEL_CONFIG::NUM_TRANSFORMER_LAYERS; i++) {
         cl_mem residual = hidden;
+        const bool residual_is_pristine = hidden_is_pristine;
 
         cl_mem normed = pre_attn_norm_[i]->forward(queue, residual, seq_len);
         if (!normed) {
             NNOPT_ERROR_FMT("pre_attn_norm forward nullptr at layer %d", i);
-            clReleaseMemObject(residual);
+            if (!residual_is_pristine) clReleaseMemObject(residual);
             return {};
         }
 
-        // Attention returns a BORROWED handle (owned by attn_[i]). DO NOT release.
-        cl_mem attn_out = attn_[i]->forward(queue, normed, seq_len, start_pos);
-        clReleaseMemObject(normed);
-        if (!attn_out) {
-            NNOPT_ERROR_FMT("attn forward nullptr at layer %d", i);
-            clReleaseMemObject(residual);
+        cl_mem after_attn_handle = attn_[i]->forward_with_residual(queue, normed, seq_len, start_pos, residual);
+        if (!after_attn_handle) {
+            NNOPT_ERROR_FMT("attn forward_with_residual nullptr at layer %d", i);
+            if (!residual_is_pristine) clReleaseMemObject(residual);
             return {};
         }
-
-        cl_mem after_attn = element_add(queue, cl_ctx_.utils_program(), residual, attn_out,
-            (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
-        clReleaseMemObject(residual);
-        // attn_out NOT released — borrowed.
-        if (!after_attn) {
-            NNOPT_ERROR_FMT("residual add failed at layer %d", i);
-            return {};
+        cl_mem after_attn = residual;
+        bool after_attn_is_pristine = residual_is_pristine;
+        if (after_attn_handle != residual) {
+            // Rare radd-ineligible path (e.g. prefill M>1). Allocates a new buffer.
+            after_attn = element_add(queue, cl_ctx_.utils_program(), residual, after_attn_handle,
+                (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
+            if (!residual_is_pristine) clReleaseMemObject(residual);
+            after_attn_is_pristine = false;
+            if (!after_attn) {
+                NNOPT_ERROR_FMT("attn fallback residual add failed at layer %d", i);
+                return {};
+            }
         }
 
         cl_mem normed2 = post_attn_norm_[i]->forward(queue, after_attn, seq_len);
         if (!normed2) {
             NNOPT_ERROR_FMT("post_attn_norm forward nullptr at layer %d", i);
-            clReleaseMemObject(after_attn);
+            if (!after_attn_is_pristine) clReleaseMemObject(after_attn);
             return {};
         }
 
-        // Mlp returns a BORROWED handle (owned by mlp_[i]). DO NOT release.
-        cl_mem mlp_out = mlp_[i]->forward(queue, normed2, seq_len);
-        clReleaseMemObject(normed2);
-        if (!mlp_out) {
-            NNOPT_ERROR_FMT("mlp forward nullptr at layer %d", i);
-            clReleaseMemObject(after_attn);
+        cl_mem after_mlp_handle = mlp_[i]->forward_with_residual(queue, normed2, seq_len, after_attn);
+        if (!after_mlp_handle) {
+            NNOPT_ERROR_FMT("mlp forward_with_residual nullptr at layer %d", i);
+            if (!after_attn_is_pristine) clReleaseMemObject(after_attn);
             return {};
         }
-
-        cl_mem after_mlp = element_add(queue, cl_ctx_.utils_program(), after_attn, mlp_out,
-            (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
-        clReleaseMemObject(after_attn);
-        // mlp_out NOT released — borrowed.
-        if (!after_mlp) {
-            NNOPT_ERROR_FMT("mlp residual add failed at layer %d", i);
-            return {};
+        cl_mem after_mlp = after_attn;
+        bool after_mlp_is_pristine = after_attn_is_pristine;
+        if (after_mlp_handle != after_attn) {
+            after_mlp = element_add(queue, cl_ctx_.utils_program(), after_attn, after_mlp_handle,
+                (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
+            if (!after_attn_is_pristine) clReleaseMemObject(after_attn);
+            after_mlp_is_pristine = false;
+            if (!after_mlp) {
+                NNOPT_ERROR_FMT("mlp fallback residual add failed at layer %d", i);
+                return {};
+            }
         }
 
         hidden = after_mlp;
+        hidden_is_pristine = after_mlp_is_pristine;
     }
 
-    // Final norm
+    // Final norm — BORROWED from final_norm_ persistent buffer.
     cl_mem final_hidden = final_norm_->forward(queue, hidden, seq_len);
-    clReleaseMemObject(hidden);
+    if (!hidden_is_pristine) clReleaseMemObject(hidden);
     if (!final_hidden) {
         NNOPT_ERROR("final_norm forward nullptr");
         return {};
     }
 
-    // LM head (tied embeddings). Use embedding weights as output projection.
-    // W shape is [vocab, hidden] in our exported weights.
     cl_mem lm_w = weights_.get_buffer("transformer.token_embeddings.weight");
     if (!lm_w) {
         NNOPT_ERROR("missing transformer.token_embeddings.weight");
-        clReleaseMemObject(final_hidden);
         return {};
     }
 
-    cl_context ctx = cl_ctx_.context();
+    if (!ensure_logits_buf_(seq_len)) return {};
     cl_int err = CL_SUCCESS;
-    cl_mem logits = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
-        (size_t)seq_len * MODEL_CONFIG::VOCAB_SIZE * sizeof(nnopt_storage_t), nullptr, &err);
-    if (err != CL_SUCCESS || !logits) {
-        NNOPT_ERROR_FMT("clCreateBuffer logits failed (%d)", err);
-        clReleaseMemObject(final_hidden);
-        return {};
-    }
 
     if (!pytorch_linear(queue, seq_len, MODEL_CONFIG::VOCAB_SIZE, MODEL_CONFIG::HIDDEN_SIZE,
-            final_hidden, lm_w, logits)) {
+            final_hidden, lm_w, logits_buf_)) {
         NNOPT_ERROR("pytorch_linear lm_head failed");
-        clReleaseMemObject(final_hidden);
-        clReleaseMemObject(logits);
         return {};
     }
-    clReleaseMemObject(final_hidden);
 
-    // Read back last-token logits only
     const size_t vocab = (size_t)MODEL_CONFIG::VOCAB_SIZE;
     std::vector<float> host_logits(vocab);
     const size_t offset_bytes = (size_t)(seq_len - 1) * vocab * sizeof(nnopt_storage_t);
 
 #ifdef NNOPT_USE_FP16
     std::vector<nnopt_storage_t> tmp(vocab);
-    err = clEnqueueReadBuffer(queue, logits, CL_TRUE, offset_bytes,
+    err = clEnqueueReadBuffer(queue, logits_buf_, CL_TRUE, offset_bytes,
         vocab * sizeof(nnopt_storage_t), tmp.data(), 0, nullptr, nullptr);
     if (err != CL_SUCCESS) {
         NNOPT_ERROR_FMT("Read logits failed (%d)", err);
-        clReleaseMemObject(logits);
         return {};
     }
     for (size_t i = 0; i < vocab; i++) host_logits[i] = nnopt_f16_to_f32(tmp[i]);
 #else
-    err = clEnqueueReadBuffer(queue, logits, CL_TRUE, offset_bytes,
+    err = clEnqueueReadBuffer(queue, logits_buf_, CL_TRUE, offset_bytes,
         vocab * sizeof(float), host_logits.data(), 0, nullptr, nullptr);
     if (err != CL_SUCCESS) {
         NNOPT_ERROR_FMT("Read logits failed (%d)", err);
-        clReleaseMemObject(logits);
         return {};
     }
 #endif
 
-    clReleaseMemObject(logits);
     NNOPT_CHECKPOINT("forward() complete");
     return host_logits;
 }
@@ -404,104 +413,98 @@ int32_t Model::forward_argmax_greedy(const std::vector<int32_t>& input_ids, int 
     cl_mem hidden = embedding_->forward(queue, input_ids.data(), seq_len, start_pos);
     if (!hidden) { NNOPT_ERROR("embedding->forward returned nullptr"); return -1; }
 
-    // Transformer blocks
+    // Transformer blocks. Step Z: pre/post norm outputs are BORROWED.
+    bool hidden_is_pristine = true;
     for (int i = 0; i < MODEL_CONFIG::NUM_TRANSFORMER_LAYERS; i++) {
         cl_mem residual = hidden;
+        const bool residual_is_pristine = hidden_is_pristine;
 
         cl_mem normed = pre_attn_norm_[i]->forward(queue, residual, seq_len);
         if (!normed) {
             NNOPT_ERROR_FMT("pre_attn_norm forward nullptr at layer %d", i);
-            clReleaseMemObject(residual);
+            if (!residual_is_pristine) clReleaseMemObject(residual);
             return -1;
         }
 
-        cl_mem attn_out = attn_[i]->forward(queue, normed, seq_len, start_pos);
-        clReleaseMemObject(normed);
-        if (!attn_out) {
-            NNOPT_ERROR_FMT("attn forward nullptr at layer %d", i);
-            clReleaseMemObject(residual);
+        cl_mem after_attn_handle = attn_[i]->forward_with_residual(queue, normed, seq_len, start_pos, residual);
+        if (!after_attn_handle) {
+            NNOPT_ERROR_FMT("attn forward_with_residual nullptr at layer %d", i);
+            if (!residual_is_pristine) clReleaseMemObject(residual);
             return -1;
         }
-
-        cl_mem after_attn = element_add(queue, cl_ctx_.utils_program(), residual, attn_out,
-            (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
-        clReleaseMemObject(residual);
-        if (!after_attn) { NNOPT_ERROR_FMT("residual add failed at layer %d", i); return -1; }
+        cl_mem after_attn = residual;
+        bool after_attn_is_pristine = residual_is_pristine;
+        if (after_attn_handle != residual) {
+            after_attn = element_add(queue, cl_ctx_.utils_program(), residual, after_attn_handle,
+                (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
+            if (!residual_is_pristine) clReleaseMemObject(residual);
+            after_attn_is_pristine = false;
+            if (!after_attn) { NNOPT_ERROR_FMT("attn fallback residual add failed at layer %d", i); return -1; }
+        }
 
         cl_mem normed2 = post_attn_norm_[i]->forward(queue, after_attn, seq_len);
         if (!normed2) {
             NNOPT_ERROR_FMT("post_attn_norm forward nullptr at layer %d", i);
-            clReleaseMemObject(after_attn);
+            if (!after_attn_is_pristine) clReleaseMemObject(after_attn);
             return -1;
         }
 
-        cl_mem mlp_out = mlp_[i]->forward(queue, normed2, seq_len);
-        clReleaseMemObject(normed2);
-        if (!mlp_out) {
-            NNOPT_ERROR_FMT("mlp forward nullptr at layer %d", i);
-            clReleaseMemObject(after_attn);
+        cl_mem after_mlp_handle = mlp_[i]->forward_with_residual(queue, normed2, seq_len, after_attn);
+        if (!after_mlp_handle) {
+            NNOPT_ERROR_FMT("mlp forward_with_residual nullptr at layer %d", i);
+            if (!after_attn_is_pristine) clReleaseMemObject(after_attn);
             return -1;
         }
-
-        cl_mem after_mlp = element_add(queue, cl_ctx_.utils_program(), after_attn, mlp_out,
-            (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
-        clReleaseMemObject(after_attn);
-        if (!after_mlp) { NNOPT_ERROR_FMT("mlp residual add failed at layer %d", i); return -1; }
+        cl_mem after_mlp = after_attn;
+        bool after_mlp_is_pristine = after_attn_is_pristine;
+        if (after_mlp_handle != after_attn) {
+            after_mlp = element_add(queue, cl_ctx_.utils_program(), after_attn, after_mlp_handle,
+                (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE);
+            if (!after_attn_is_pristine) clReleaseMemObject(after_attn);
+            after_mlp_is_pristine = false;
+            if (!after_mlp) { NNOPT_ERROR_FMT("mlp fallback residual add failed at layer %d", i); return -1; }
+        }
 
         hidden = after_mlp;
+        hidden_is_pristine = after_mlp_is_pristine;
     }
 
-    // Final norm
     cl_mem final_hidden = final_norm_->forward(queue, hidden, seq_len);
-    clReleaseMemObject(hidden);
+    if (!hidden_is_pristine) clReleaseMemObject(hidden);
     if (!final_hidden) { NNOPT_ERROR("final_norm forward nullptr"); return -1; }
 
-    // LM head (tied embeddings)
     cl_mem lm_w = weights_.get_buffer("transformer.token_embeddings.weight");
     if (!lm_w) {
         NNOPT_ERROR("missing transformer.token_embeddings.weight");
-        clReleaseMemObject(final_hidden);
         return -1;
     }
 
+    if (!ensure_logits_buf_(seq_len)) return -1;
     cl_int err = CL_SUCCESS;
-    cl_mem logits = clCreateBuffer(cl_ctx_.context(), CL_MEM_READ_WRITE,
-        (size_t)seq_len * MODEL_CONFIG::VOCAB_SIZE * sizeof(nnopt_storage_t), nullptr, &err);
-    if (err != CL_SUCCESS || !logits) {
-        NNOPT_ERROR_FMT("clCreateBuffer logits failed (%d)", err);
-        clReleaseMemObject(final_hidden);
-        return -1;
-    }
 
     if (!pytorch_linear(queue, seq_len, MODEL_CONFIG::VOCAB_SIZE, MODEL_CONFIG::HIDDEN_SIZE,
-            final_hidden, lm_w, logits)) {
+            final_hidden, lm_w, logits_buf_)) {
         NNOPT_ERROR("pytorch_linear lm_head failed");
-        clReleaseMemObject(final_hidden);
-        clReleaseMemObject(logits);
         return -1;
     }
-    clReleaseMemObject(final_hidden);
 
-    // GPU argmax over the LAST token's logits row only. Pass offset_elements
-    // instead of clCreateSubBuffer (Adreno alignment quirks).
     const int vocab = MODEL_CONFIG::VOCAB_SIZE;
     const int offset_elements = (seq_len - 1) * vocab;
 
-    if (clSetKernelArg(argmax_kernel_, 0, sizeof(cl_mem), &logits) != CL_SUCCESS ||
+    if (clSetKernelArg(argmax_kernel_, 0, sizeof(cl_mem), &logits_buf_) != CL_SUCCESS ||
         clSetKernelArg(argmax_kernel_, 1, sizeof(cl_mem), &argmax_result_) != CL_SUCCESS ||
         clSetKernelArg(argmax_kernel_, 2, sizeof(int),    &vocab) != CL_SUCCESS ||
         clSetKernelArg(argmax_kernel_, 3, sizeof(int),    &offset_elements) != CL_SUCCESS) {
         NNOPT_ERROR("argmax setKernelArg failed");
-        clReleaseMemObject(logits);
         return -1;
     }
     {
         const size_t lws = 256;
         const size_t gws = 256;
-        err = clEnqueueNDRangeKernel(queue, argmax_kernel_, 1, nullptr, &gws, &lws, 0, nullptr, nullptr);
+        cl_event* evt = KernelProfiler::event_for("argmax");
+        err = clEnqueueNDRangeKernel(queue, argmax_kernel_, 1, nullptr, &gws, &lws, 0, nullptr, evt);
         if (err != CL_SUCCESS) {
             NNOPT_ERROR_FMT("argmax dispatch failed: %d", (int)err);
-            clReleaseMemObject(logits);
             return -1;
         }
     }
@@ -509,13 +512,88 @@ int32_t Model::forward_argmax_greedy(const std::vector<int32_t>& input_ids, int 
     int32_t result = -1;
     err = clEnqueueReadBuffer(queue, argmax_result_, CL_TRUE, 0,
                               sizeof(int32_t), &result, 0, nullptr, nullptr);
-    clReleaseMemObject(logits);
     if (err != CL_SUCCESS) {
         NNOPT_ERROR_FMT("Read argmax result failed (%d)", err);
         return -1;
     }
     NNOPT_CHECKPOINT("forward_argmax_greedy() complete");
     return result;
+}
+
+// Step 9: chained-decode forward. Embedding reads from argmax_result_
+// (written by the previous forward); argmax writes back to argmax_result_.
+// No host readback inside this function — caller pipelines a CL_FALSE
+// readback of argmax_result_buffer() and waits on the event when needed.
+bool Model::forward_argmax_greedy_chained_enqueue(int start_pos) {
+    const int seq_len = 1;
+    if (!ensure_argmax_resources_()) return false;
+    cl_command_queue queue = cl_ctx_.queue();
+
+    cl_mem hidden = embedding_->forward_from_device_token(
+        queue, argmax_result_, /*dev_offset_bytes=*/0, start_pos);
+    if (!hidden) return false;
+
+    for (int i = 0; i < MODEL_CONFIG::NUM_TRANSFORMER_LAYERS; i++) {
+        cl_mem residual = hidden;
+        cl_mem normed = pre_attn_norm_[i]->forward(queue, residual, seq_len);
+        if (!normed) { clReleaseMemObject(residual); return false; }
+
+        cl_mem after_attn_handle = attn_[i]->forward_with_residual(queue, normed, seq_len, start_pos, residual);
+        if (!after_attn_handle) return false;
+        // At decode (seq_len=1) the radd path always fires, so after_attn ==
+        // residual every iteration. We don't bother with the fallback element_add
+        // path here (it's covered by forward()/forward_argmax_greedy for prefill
+        // and non-greedy paths). Keep the branch as a defensive sanity check.
+        if (after_attn_handle != residual) {
+            NNOPT_ERROR_FMT("chained decode hit unexpected radd-ineligible path at layer %d", i);
+            return false;
+        }
+        cl_mem after_attn = residual;
+
+        cl_mem normed2 = post_attn_norm_[i]->forward(queue, after_attn, seq_len);
+        if (!normed2) return false;
+
+        cl_mem after_mlp_handle = mlp_[i]->forward_with_residual(queue, normed2, seq_len, after_attn);
+        if (!after_mlp_handle) return false;
+        if (after_mlp_handle != after_attn) {
+            NNOPT_ERROR_FMT("chained decode hit unexpected mlp-radd-ineligible path at layer %d", i);
+            return false;
+        }
+        cl_mem after_mlp = after_attn;
+
+        hidden = after_mlp;
+    }
+
+    cl_mem final_hidden = final_norm_->forward(queue, hidden, seq_len);
+    if (!final_hidden) return false;
+
+    cl_mem lm_w = weights_.get_buffer("transformer.token_embeddings.weight");
+    if (!lm_w) return false;
+
+    if (!ensure_logits_buf_(seq_len)) return false;
+    cl_int err = CL_SUCCESS;
+
+    if (!pytorch_linear(queue, seq_len, MODEL_CONFIG::VOCAB_SIZE, MODEL_CONFIG::HIDDEN_SIZE,
+            final_hidden, lm_w, logits_buf_)) {
+        return false;
+    }
+
+    const int vocab = MODEL_CONFIG::VOCAB_SIZE;
+    const int offset_elements = (seq_len - 1) * vocab;
+    if (clSetKernelArg(argmax_kernel_, 0, sizeof(cl_mem), &logits_buf_) != CL_SUCCESS ||
+        clSetKernelArg(argmax_kernel_, 1, sizeof(cl_mem), &argmax_result_) != CL_SUCCESS ||
+        clSetKernelArg(argmax_kernel_, 2, sizeof(int),    &vocab) != CL_SUCCESS ||
+        clSetKernelArg(argmax_kernel_, 3, sizeof(int),    &offset_elements) != CL_SUCCESS) {
+        return false;
+    }
+    {
+        const size_t lws = 256;
+        const size_t gws = 256;
+        cl_event* evt = KernelProfiler::event_for("argmax_chained");
+        err = clEnqueueNDRangeKernel(queue, argmax_kernel_, 1, nullptr, &gws, &lws, 0, nullptr, evt);
+        if (err != CL_SUCCESS) return false;
+    }
+    return true;
 }
 
 // ── Decode fast path (OPTIONAL — single-token forward) ──────────────────
@@ -636,7 +714,80 @@ std::vector<int32_t> Model::generate(
         return ids;
     }
 
-    // Decode loop: each step processes ONE new token.
+    // Step 9 fast path: pipelined chained decode. Embedding reads its token
+    // directly from argmax_result_ (written by the previous step), and the
+    // host readback is async — we wait on iteration N's readback only after
+    // enqueueing iteration N+1's GPU work, hiding the readback latency
+    // behind the next forward's enqueue.
+    if (greedy_fast && max_new_tokens > 1) {
+        cl_command_queue queue = cl_ctx_.queue();
+        // Two-slot ping-pong host buffer + events for async readback. The
+        // value written by readback at slot s captures argmax_result_'s state
+        // at the time the readback was *enqueued* (in-order queue), which is
+        // immediately after the corresponding forward's argmax kernel.
+        int32_t host_int[2] = {0, 0};
+        cl_event readback_event[2] = {nullptr, nullptr};
+        bool slot_pending[2] = {false, false};
+        int prev_slot = -1;
+
+        bool eos_seen = false;
+        for (int i = 1; i < max_new_tokens && !eos_seen; i++) {
+            const int start_pos = (int)prompt_ids.size() + (i - 1);
+            const int cur_slot = i & 1;
+
+            if (!forward_argmax_greedy_chained_enqueue(start_pos)) {
+                NNOPT_ERROR("chained decode forward failed");
+                break;
+            }
+
+            // Async readback of the value just written by argmax.
+            cl_int rerr = clEnqueueReadBuffer(queue, argmax_result_, CL_FALSE, 0,
+                                              sizeof(int32_t), &host_int[cur_slot],
+                                              0, nullptr, &readback_event[cur_slot]);
+            if (rerr != CL_SUCCESS) {
+                NNOPT_ERROR_FMT("chained async readback enqueue failed (%d)", (int)rerr);
+                break;
+            }
+            slot_pending[cur_slot] = true;
+            // Make sure the GPU starts working — flush after enqueue.
+            clFlush(queue);
+
+            // Drain the previous iteration's int32: this is the token we just
+            // generated one step ago.
+            if (prev_slot >= 0 && slot_pending[prev_slot]) {
+                clWaitForEvents(1, &readback_event[prev_slot]);
+                clReleaseEvent(readback_event[prev_slot]);
+                readback_event[prev_slot] = nullptr;
+                slot_pending[prev_slot] = false;
+                int32_t t = host_int[prev_slot];
+                ids.push_back(t);
+                generated.push_back(t);
+                if (on_token) on_token(t);
+                if (sampler_config.eos_token_id >= 0 && t == sampler_config.eos_token_id) {
+                    eos_seen = true;
+                }
+            }
+            prev_slot = cur_slot;
+        }
+
+        // Drain the in-flight final readback.
+        if (prev_slot >= 0 && slot_pending[prev_slot]) {
+            clWaitForEvents(1, &readback_event[prev_slot]);
+            clReleaseEvent(readback_event[prev_slot]);
+            readback_event[prev_slot] = nullptr;
+            slot_pending[prev_slot] = false;
+            if (!eos_seen) {
+                int32_t t = host_int[prev_slot];
+                ids.push_back(t);
+                generated.push_back(t);
+                if (on_token) on_token(t);
+            }
+        }
+        NNOPT_CHECKPOINT("generate() complete (chained)");
+        return ids;
+    }
+
+    // Decode loop: each step processes ONE new token (non-greedy or 1-token).
     for (int i = 1; i < max_new_tokens; i++) {
         const int start_pos = (int)prompt_ids.size() + (i - 1);
         std::vector<int32_t> single = { next_token };

--- a/src/models/openelm-270m/src/model.h
+++ b/src/models/openelm-270m/src/model.h
@@ -53,6 +53,14 @@ public:
     // sampler.temperature<=0 AND repetition_penalty==1. Returns -1 on error.
     int32_t forward_argmax_greedy(const std::vector<int32_t>& input_ids, int start_pos);
 
+    // Step 9: enqueue-only chained variant. Reads its single input token from
+    // argmax_result_ (written by the previous forward) instead of host memory,
+    // and DOES NOT block on a host readback. Caller is responsible for
+    // pipelining a CL_FALSE clEnqueueReadBuffer of argmax_result_ if it needs
+    // the int32 on the host (e.g. for streaming/EOS). Returns true on success.
+    bool forward_argmax_greedy_chained_enqueue(int start_pos);
+    cl_mem argmax_result_buffer() const { return argmax_result_; }
+
     // Streaming callback: invoked once per newly-generated token (NOT for
     // prompt tokens). Use this to print/decode tokens live as they are
     // produced. Runs synchronously on the generate() thread between tokens —
@@ -83,6 +91,11 @@ private:
     cl_program argmax_program_ = nullptr;
     cl_kernel  argmax_kernel_  = nullptr;
     cl_mem     argmax_result_  = nullptr;   // 1 × int32 device buffer
+
+    // Step Z: persistent logits buffer for the lm_head. Sticky capacity.
+    cl_mem  logits_buf_ = nullptr;
+    size_t  logits_buf_cap_bytes_ = 0;
+    bool ensure_logits_buf_(int seq_len);
 
     bool ensure_argmax_resources_();
 

--- a/src/models/openelm-270m/src/opencl_context.cpp
+++ b/src/models/openelm-270m/src/opencl_context.cpp
@@ -8,6 +8,9 @@
 #include <cstdint>
 #include <sys/stat.h>
 #include <dlfcn.h>
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#endif
 
 // ──────────────────────────────────────────────────────────────────────
 // Program binary cache — fixes the cold-start TTFT problem (~30 s
@@ -193,11 +196,14 @@ bool OpenCLContext::initialize(int platform_idx, int device_idx) {
 
     // CL_QUEUE_PROFILING_ENABLE forces the GPU to record start/end timestamps
     // on every dispatch — measurable overhead (~1–3% at our 240-disp/tok rate).
-    // Only set it when the per-kernel profiler is requested via NNOPT_PROFILE=1.
+    // Only set it when the per-kernel profiler is requested. Accept both
+    // legacy NNOPT_PROFILE and the canonical NNOPT_KERNEL_PROFILE env names
+    // (the latter is what the kernel_profiler.h ports use).
     cl_command_queue_properties q_props = 0;
     {
-        const char* e = std::getenv("NNOPT_PROFILE");
-        if (e && e[0] == '1') q_props |= CL_QUEUE_PROFILING_ENABLE;
+        const char* e1 = std::getenv("NNOPT_PROFILE");
+        const char* e2 = std::getenv("NNOPT_KERNEL_PROFILE");
+        if ((e1 && e1[0] == '1') || (e2 && e2[0] == '1')) q_props |= CL_QUEUE_PROFILING_ENABLE;
     }
     queue_ = clCreateCommandQueue(context_, device_, q_props, &err);
     if (err != CL_SUCCESS) return false;
@@ -346,6 +352,103 @@ size_t OpenCLContext::local_mem_size() const {
     cl_ulong size;
     clGetDeviceInfo(device_, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(size), &size, nullptr);
     return (size_t)size;
+}
+
+std::string OpenCLContext::device_description() const {
+    auto str = [&](cl_device_info q) -> std::string {
+        char buf[512] = {0};
+        if (clGetDeviceInfo(device_, q, sizeof(buf), buf, nullptr) != CL_SUCCESS) return "?";
+        return std::string(buf);
+    };
+    auto u32 = [&](cl_device_info q) -> std::string {
+        cl_uint v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return "?";
+        return std::to_string(v);
+    };
+    auto u64_bytes = [&](cl_device_info q) -> cl_ulong {
+        cl_ulong v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return 0;
+        return v;
+    };
+
+    // Adreno's KGSL driver exposes the actual GPU model at /sys/class/kgsl/...
+    // Older driver builds return only "QUALCOMM Adreno(TM)" via CL_DEVICE_NAME
+    // (no chip number); splice the sysfs model in when CL_DEVICE_NAME lacks digits.
+    std::string name = device_name();
+    bool name_has_digit = false;
+    for (char c : name) if (c >= '0' && c <= '9') { name_has_digit = true; break; }
+    if (!name_has_digit) {
+        std::ifstream f("/sys/class/kgsl/kgsl-3d0/gpu_model");
+        std::string m;
+        if (f.is_open() && std::getline(f, m)) {
+            while (!m.empty() && (m.back() == '\n' || m.back() == '\r' || m.back() == ' ')) m.pop_back();
+            // "Adreno620v2" -> "Adreno 620v2"
+            size_t apos = m.find("Adreno");
+            if (apos != std::string::npos && apos + 6 < m.size() &&
+                m[apos + 6] >= '0' && m[apos + 6] <= '9') {
+                m.insert(apos + 6, " ");
+            }
+            const std::string tm_marker = "Adreno(TM)";
+            size_t tm = name.find(tm_marker);
+            if (!m.empty() && tm != std::string::npos) {
+                name.replace(tm, tm_marker.size(), m);
+            } else if (!m.empty()) {
+                name += " (" + m + ")";
+            }
+        }
+    }
+
+    // CL_DEVICE_VERSION is "OpenCL X.Y <impl details>" — keep just "X.Y".
+    std::string ver = str(CL_DEVICE_VERSION);
+    if (ver.rfind("OpenCL ", 0) == 0) {
+        size_t sp = ver.find(' ', 7);
+        ver = (sp == std::string::npos) ? ver.substr(7) : ver.substr(7, sp - 7);
+    }
+
+    // CL_DRIVER_VERSION on Adreno is a verbose build banner. The only piece
+    // that meaningfully changes between driver releases is the "Compiler EXXX..."
+    // token — extract it; fall back to first whitespace-token otherwise.
+    std::string drv = str(CL_DRIVER_VERSION);
+    {
+        size_t pos = drv.find("Compiler ");
+        if (pos != std::string::npos) drv = drv.substr(pos + 9);
+        size_t end = drv.find_first_of(" \t\r\n");
+        if (end != std::string::npos) drv = drv.substr(0, end);
+    }
+
+    cl_ulong gmem = u64_bytes(CL_DEVICE_GLOBAL_MEM_SIZE);
+    cl_ulong lmem = u64_bytes(CL_DEVICE_LOCAL_MEM_SIZE);
+    char gbuf[32], lbuf[32];
+    snprintf(gbuf, sizeof(gbuf), "%.1f GB", gmem / 1e9);
+    snprintf(lbuf, sizeof(lbuf), "%llu KB", (unsigned long long)(lmem / 1024));
+
+    // Android SoC model + platform codename. OpenCL exposes neither, so this
+    // is the only way to surface the actual chip (e.g. SM7250 / lito).
+    std::string soc;
+#ifdef __ANDROID__
+    {
+        char model[PROP_VALUE_MAX] = {0};
+        char board[PROP_VALUE_MAX] = {0};
+        __system_property_get("ro.soc.model", model);
+        __system_property_get("ro.board.platform", board);
+        if (model[0]) {
+            soc = model;
+            if (board[0]) soc += " (" + std::string(board) + ")";
+        } else if (board[0]) {
+            soc = board;
+        }
+    }
+#endif
+
+    std::ostringstream os;
+    os << name << "\n";
+    if (!soc.empty()) os << "  SoC:    " << soc << "\n";
+    os << "  Memory: " << gbuf << " global / " << lbuf << " local\n"
+       << "  CUs:    " << u32(CL_DEVICE_MAX_COMPUTE_UNITS) << "\n"
+       << "  Clock:  " << u32(CL_DEVICE_MAX_CLOCK_FREQUENCY) << " MHz\n"
+       << "  OpenCL: " << ver << "\n"
+       << "  Driver: " << drv;
+    return os.str();
 }
 
 cl_program OpenCLContext::utils_program() {

--- a/src/models/openelm-270m/src/opencl_context.h
+++ b/src/models/openelm-270m/src/opencl_context.h
@@ -27,6 +27,7 @@ public:
 
     // Device info
     std::string device_name() const;
+    std::string device_description() const;
     size_t max_work_group_size() const;
     size_t local_mem_size() const;
 

--- a/src/models/openelm-270m/src/utils.cpp
+++ b/src/models/openelm-270m/src/utils.cpp
@@ -1,11 +1,13 @@
 #include "utils.h"
 #include "debug_utils.h"   // NNOPT_ERROR_FMT — used by element_add / pytorch_linear / etc.
+#include "kernel_profiler.h"
 
 #include <clblast.h>       // clblast::Gemm — used by pytorch_linear (dtype-templated dispatch).
 
 #include <fstream>
 #include <sstream>
 #include <cstring>
+#include <cstdio>
 #include <algorithm>
 #include <numeric>
 #include <cstdint>
@@ -27,6 +29,13 @@
 static bool try_gemv_m1_fast_path(cl_command_queue queue,
                                   int N, int K,
                                   cl_mem x, cl_mem W, cl_mem out);
+
+// gemv_m1 fast path with FUSED RESIDUAL ADD. See pytorch_linear_radd().
+// Reads `hidden[n]`, computes the dot product, writes `hidden[n] = sum + r`.
+// Returns false if the K/N pair is not eligible (M=1 implied, K%64==0, N%4==0).
+static bool try_gemv_m1_radd_fast_path(cl_command_queue queue,
+                                       int N, int K,
+                                       cl_mem x, cl_mem W, cl_mem hidden);
 
 // ──────────────────────────────────────────────
 // IEEE 754 binary16 codec (host-side).
@@ -212,7 +221,8 @@ bool element_add_inplace(cl_command_queue queue, cl_program utils_program,
     err = clSetKernelArg(s_cached_kernel, 2, sizeof(int), &n_int);
     if (err != CL_SUCCESS) { NNOPT_ERROR_FMT("element_add_inplace arg2: %d", err); return false; }
     size_t gws = n;
-    err = clEnqueueNDRangeKernel(queue, s_cached_kernel, 1, nullptr, &gws, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("element_add_inplace");
+    err = clEnqueueNDRangeKernel(queue, s_cached_kernel, 1, nullptr, &gws, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) {
         NNOPT_ERROR_FMT("element_add_inplace: clEnqueueNDRangeKernel failed (%d)", err);
         return false;
@@ -254,7 +264,8 @@ cl_mem element_add(cl_command_queue queue, cl_program utils_program, cl_mem a, c
     clSetKernelArg(kernel, 2, sizeof(int), &n_int);
 
     size_t global_size = n;
-    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &global_size, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("element_add");
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &global_size, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) {
         NNOPT_ERROR_FMT("element_add: clEnqueueNDRangeKernel failed (%d)", err);
     }
@@ -280,7 +291,8 @@ bool split_last_dim_2(cl_command_queue queue, cl_program utils_program,
     clSetKernelArg(kernel, 4, sizeof(int), &half_cols);
 
     size_t global_size = (size_t)rows * (size_t)half_cols;
-    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &global_size, nullptr, 0, nullptr, nullptr);
+    cl_event* evt = KernelProfiler::event_for("split_last_dim_2");
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &global_size, nullptr, 0, nullptr, evt);
     if (err != CL_SUCCESS) {
         NNOPT_ERROR_FMT("split_last_dim_2: clEnqueueNDRangeKernel failed (%d)", err);
         clReleaseKernel(kernel);
@@ -366,6 +378,15 @@ bool pytorch_linear(cl_command_queue queue,
     return true;
 }
 
+bool pytorch_linear_radd(cl_command_queue queue,
+                         int M, int N, int K,
+                         cl_mem x, cl_mem W, cl_mem hidden) {
+    // Eligibility: M=1, K%64==0, N%4==0. Anything else falls back to caller's
+    // pytorch_linear + element_add_inplace path.
+    if (M != 1 || K < 64 || (K % 64) != 0 || (N % 4) != 0) return false;
+    return try_gemv_m1_radd_fast_path(queue, N, K, x, W, hidden);
+}
+
 bool pytorch_conv1d(cl_command_queue queue,
                     int M, int N, int K,
                     cl_mem x, cl_mem W, cl_mem out) {
@@ -428,76 +449,93 @@ bool pytorch_conv1d(cl_command_queue queue,
 // ──────────────────────────────────────────────
 // gemv_m1 fast-path implementation. See declaration above pytorch_linear.
 // ──────────────────────────────────────────────
+// Shared program for all gemv_m1 kernels (fast-path + radd). Building the
+// program once per process eliminates a per-program-pair scheduling cost on
+// Adreno where switching kernel objects across cl_program boundaries
+// appears to flush some driver state.
+static cl_program s_gemv_program = nullptr;
+static bool s_gemv_init_failed = false;
+static cl_kernel s_k_768           = nullptr;
+static cl_kernel s_k_1536          = nullptr;
+static cl_kernel s_k_768_no4       = nullptr;
+static cl_kernel s_k_1280_no4      = nullptr;
+static cl_kernel s_k_1536_no4      = nullptr;
+static cl_kernel s_k_generic       = nullptr;
+static cl_kernel s_k_generic_no4   = nullptr;
+static cl_kernel s_k_generic_no4_coalesced = nullptr;
+static cl_kernel s_k_1280_no4_radd    = nullptr;
+static cl_kernel s_k_generic_no4_radd = nullptr;
+static cl_kernel s_k_generic_no4_radd_coalesced = nullptr;
+
+static bool ensure_gemv_program(cl_command_queue queue) {
+    if (s_gemv_init_failed) return false;
+    if (s_gemv_program) return true;
+
+    cl_context ctx = nullptr;
+    cl_device_id dev = nullptr;
+    clGetCommandQueueInfo(queue, CL_QUEUE_CONTEXT, sizeof(ctx), &ctx, nullptr);
+    clGetCommandQueueInfo(queue, CL_QUEUE_DEVICE, sizeof(dev), &dev, nullptr);
+    if (!ctx || !dev) { s_gemv_init_failed = true; return false; }
+
+    std::ifstream f("kernels/gemv_m1.cl");
+    if (!f.is_open()) {
+        NNOPT_ERROR("gemv_m1: cannot open kernels/gemv_m1.cl");
+        s_gemv_init_failed = true;
+        return false;
+    }
+    std::stringstream buf; buf << f.rdbuf();
+    std::string src = buf.str();
+    const char* src_ptr = src.c_str();
+    size_t src_len = src.size();
+
+    cl_int err = CL_SUCCESS;
+    s_gemv_program = clCreateProgramWithSource(ctx, 1, &src_ptr, &src_len, &err);
+    if (err != CL_SUCCESS || !s_gemv_program) {
+        NNOPT_ERROR_FMT("gemv_m1: clCreateProgramWithSource failed (%d)", (int)err);
+        s_gemv_init_failed = true;
+        return false;
+    }
+#ifdef NNOPT_USE_FP16
+    const char* opts = "-D USE_FP16=1";
+#else
+    const char* opts = "";
+#endif
+    err = clBuildProgram(s_gemv_program, 1, &dev, opts, nullptr, nullptr);
+    if (err != CL_SUCCESS) {
+        size_t log_size = 0;
+        clGetProgramBuildInfo(s_gemv_program, dev, CL_PROGRAM_BUILD_LOG, 0, nullptr, &log_size);
+        std::vector<char> log(log_size + 1, 0);
+        clGetProgramBuildInfo(s_gemv_program, dev, CL_PROGRAM_BUILD_LOG, log_size, log.data(), nullptr);
+        NNOPT_ERROR_FMT("gemv_m1: build failed (%d): %s", (int)err, log.data());
+        clReleaseProgram(s_gemv_program);
+        s_gemv_program = nullptr;
+        s_gemv_init_failed = true;
+        return false;
+    }
+
+    s_k_768              = clCreateKernel(s_gemv_program, "gemv_m1_k768",       &err);
+    s_k_1536             = clCreateKernel(s_gemv_program, "gemv_m1_k1536",      &err);
+    s_k_768_no4          = clCreateKernel(s_gemv_program, "gemv_m1_k768_no4",   &err);
+    s_k_1280_no4         = clCreateKernel(s_gemv_program, "gemv_m1_k1280_no4",  &err);
+    s_k_1536_no4         = clCreateKernel(s_gemv_program, "gemv_m1_k1536_no4",  &err);
+    s_k_generic          = clCreateKernel(s_gemv_program, "gemv_m1",            &err);
+    s_k_generic_no4      = clCreateKernel(s_gemv_program, "gemv_m1_no4",        &err);
+    s_k_generic_no4_coalesced       = clCreateKernel(s_gemv_program, "gemv_m1_no4_coalesced",       &err);
+    s_k_1280_no4_radd    = clCreateKernel(s_gemv_program, "gemv_m1_k1280_no4_radd", &err);
+    s_k_generic_no4_radd = clCreateKernel(s_gemv_program, "gemv_m1_no4_radd",   &err);
+    s_k_generic_no4_radd_coalesced  = clCreateKernel(s_gemv_program, "gemv_m1_no4_radd_coalesced",  &err);
+    if (!s_k_generic || !s_k_generic_no4 || !s_k_generic_no4_radd) {
+        NNOPT_ERROR("gemv_m1: clCreateKernel for one of the generic kernels failed");
+        s_gemv_init_failed = true;
+        return false;
+    }
+    return true;
+}
+
 static bool try_gemv_m1_fast_path(cl_command_queue queue,
                                   int N, int K,
                                   cl_mem x, cl_mem W, cl_mem out) {
-    static cl_program s_program = nullptr;
-    static cl_kernel s_k_768       = nullptr;
-    static cl_kernel s_k_1536      = nullptr;
-    static cl_kernel s_k_768_no4   = nullptr;
-    static cl_kernel s_k_1536_no4  = nullptr;
-    static cl_kernel s_k_generic   = nullptr;
-    static cl_kernel s_k_generic_no4 = nullptr;
-    static bool s_init_failed = false;
-    if (s_init_failed) return false;
-
-    if (!s_program) {
-        // Bootstrap context+device from the queue (pytorch_linear's signature
-        // doesn't pass an OpenCLContext handle, so we self-discover here once).
-        cl_context ctx = nullptr;
-        cl_device_id dev = nullptr;
-        clGetCommandQueueInfo(queue, CL_QUEUE_CONTEXT, sizeof(ctx), &ctx, nullptr);
-        clGetCommandQueueInfo(queue, CL_QUEUE_DEVICE, sizeof(dev), &dev, nullptr);
-        if (!ctx || !dev) { s_init_failed = true; return false; }
-
-        std::ifstream f("kernels/gemv_m1.cl");
-        if (!f.is_open()) {
-            NNOPT_ERROR("gemv_m1: cannot open kernels/gemv_m1.cl");
-            s_init_failed = true;
-            return false;
-        }
-        std::stringstream buf; buf << f.rdbuf();
-        std::string src = buf.str();
-        const char* src_ptr = src.c_str();
-        size_t src_len = src.size();
-
-        cl_int err = CL_SUCCESS;
-        s_program = clCreateProgramWithSource(ctx, 1, &src_ptr, &src_len, &err);
-        if (err != CL_SUCCESS || !s_program) {
-            NNOPT_ERROR_FMT("gemv_m1: clCreateProgramWithSource failed (%d)", (int)err);
-            s_init_failed = true;
-            return false;
-        }
-#ifdef NNOPT_USE_FP16
-        const char* opts = "-D USE_FP16=1";
-#else
-        const char* opts = "";
-#endif
-        err = clBuildProgram(s_program, 1, &dev, opts, nullptr, nullptr);
-        if (err != CL_SUCCESS) {
-            size_t log_size = 0;
-            clGetProgramBuildInfo(s_program, dev, CL_PROGRAM_BUILD_LOG, 0, nullptr, &log_size);
-            std::vector<char> log(log_size + 1, 0);
-            clGetProgramBuildInfo(s_program, dev, CL_PROGRAM_BUILD_LOG, log_size, log.data(), nullptr);
-            NNOPT_ERROR_FMT("gemv_m1: build failed (%d): %s", (int)err, log.data());
-            clReleaseProgram(s_program);
-            s_program = nullptr;
-            s_init_failed = true;
-            return false;
-        }
-
-        s_k_768          = clCreateKernel(s_program, "gemv_m1_k768",      &err);
-        s_k_1536         = clCreateKernel(s_program, "gemv_m1_k1536",     &err);
-        s_k_768_no4      = clCreateKernel(s_program, "gemv_m1_k768_no4",  &err);
-        s_k_1536_no4     = clCreateKernel(s_program, "gemv_m1_k1536_no4", &err);
-        s_k_generic      = clCreateKernel(s_program, "gemv_m1",           &err);
-        s_k_generic_no4  = clCreateKernel(s_program, "gemv_m1_no4",       &err);
-        if (!s_k_generic || !s_k_generic_no4) {
-            NNOPT_ERROR("gemv_m1: clCreateKernel for generic kernels failed");
-            s_init_failed = true;
-            return false;
-        }
-    }
+    if (!ensure_gemv_program(queue)) return false;
 
     // Pick the most specialized kernel for this (K, N) pair.
     //   K=768  with N%4==0 → gemv_m1_k768_no4
@@ -509,10 +547,12 @@ static bool try_gemv_m1_fast_path(cl_command_queue queue,
     bool is_no4 = (N % 4 == 0);
     bool needs_K_arg = false;
 
-    if (K == 768  && is_no4) { kernel = s_k_768_no4;  }
+    if (K == 768  && is_no4)      { kernel = s_k_768_no4;  }
+    else if (K == 1280 && is_no4) { kernel = s_k_1280_no4; }
     else if (K == 1536 && is_no4) { kernel = s_k_1536_no4; }
     else if (K == 768)            { kernel = s_k_768;      }
     else if (K == 1536)           { kernel = s_k_1536;     }
+    else if (is_no4 && (K % 256 == 0)) { kernel = s_k_generic_no4_coalesced; needs_K_arg = true; }
     else if (is_no4)              { kernel = s_k_generic_no4; needs_K_arg = true; }
     else                          { kernel = s_k_generic;     needs_K_arg = true; }
 
@@ -532,14 +572,75 @@ static bool try_gemv_m1_fast_path(cl_command_queue queue,
 
     constexpr size_t WG = 64;
     size_t gws, lws = WG;
-    if (kernel == s_k_768_no4 || kernel == s_k_1536_no4 || kernel == s_k_generic_no4) {
+    if (kernel == s_k_768_no4 || kernel == s_k_1280_no4 || kernel == s_k_1536_no4 ||
+        kernel == s_k_generic_no4 || kernel == s_k_generic_no4_coalesced) {
         gws = (size_t)(N / 4) * WG;
     } else {
         gws = (size_t)N * WG;
     }
-    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &gws, &lws, 0, nullptr, nullptr);
+    char prof_label[48];
+    std::snprintf(prof_label, sizeof(prof_label), "gemv_m1_K%d_N%d", K, N);
+    cl_event* evt = KernelProfiler::event_for(prof_label);
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &gws, &lws, 0, nullptr, evt);
     if (err != CL_SUCCESS) {
         NNOPT_ERROR_FMT("gemv_m1: clEnqueueNDRangeKernel failed (%d) (K=%d N=%d)", (int)err, K, N);
+        return false;
+    }
+    NNOPT_DEBUG_SYNC(queue);
+    return true;
+}
+
+// ──────────────────────────────────────────────
+// gemv_m1 fused-residual-add fast-path implementation. Shares the same
+// cl_program as try_gemv_m1_fast_path so successive launches don't bounce
+// across program objects (Adreno appears to flush some scheduler state
+// when alternating cl_kernels from different programs).
+// ──────────────────────────────────────────────
+static bool try_gemv_m1_radd_fast_path(cl_command_queue queue,
+                                       int N, int K,
+                                       cl_mem x, cl_mem W, cl_mem hidden) {
+    if (!ensure_gemv_program(queue)) return false;
+
+    // Pick the K-specialized radd variant when available; otherwise prefer
+    // the coalesced generic when K%256==0; fall back to the un-coalesced
+    // generic only for K%64==0 && K%256!=0 (no decode-path K hits this on
+    // OpenELM, but keep the path for safety).
+    cl_kernel kernel = nullptr;
+    bool needs_K_arg = false;
+    if (K == 1280) {
+        kernel = s_k_1280_no4_radd;
+    } else if (K % 256 == 0) {
+        kernel = s_k_generic_no4_radd_coalesced;
+        needs_K_arg = true;
+    } else {
+        kernel = s_k_generic_no4_radd;
+        needs_K_arg = true;
+    }
+
+    cl_int err = CL_SUCCESS;
+    cl_uint a = 0;
+    err |= clSetKernelArg(kernel, a++, sizeof(cl_mem), &x);
+    err |= clSetKernelArg(kernel, a++, sizeof(cl_mem), &W);
+    err |= clSetKernelArg(kernel, a++, sizeof(cl_mem), &hidden);
+    if (needs_K_arg) {
+        err |= clSetKernelArg(kernel, a++, sizeof(int), &K);
+    }
+    err |= clSetKernelArg(kernel, a++, sizeof(int), &N);
+    if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("gemv_m1_radd: clSetKernelArg failed (%d)", (int)err);
+        return false;
+    }
+
+    constexpr size_t WG = 64;
+    const size_t gws = (size_t)(N / 4) * WG;
+    const size_t lws = WG;
+
+    char prof_label[64];
+    std::snprintf(prof_label, sizeof(prof_label), "gemv_m1_K%d_N%d_radd", K, N);
+    cl_event* evt = KernelProfiler::event_for(prof_label);
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &gws, &lws, 0, nullptr, evt);
+    if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("gemv_m1_radd: clEnqueueNDRangeKernel failed (%d) (K=%d N=%d)", (int)err, K, N);
         return false;
     }
     NNOPT_DEBUG_SYNC(queue);

--- a/src/models/openelm-270m/src/utils.h
+++ b/src/models/openelm-270m/src/utils.h
@@ -119,6 +119,25 @@ bool pytorch_linear(cl_command_queue queue,
                     cl_mem x, cl_mem W, cl_mem out);
 
 // ──────────────────────────────────────────────
+// pytorch_linear_radd: nn.Linear GEMM with FUSED RESIDUAL ADD
+// ──────────────────────────────────────────────
+// Computes: hidden[i] += x @ W[i]^T   (in-place; hidden is the residual stream)
+//
+// Mathematically equivalent to:
+//   pytorch_linear(queue, M=1, N, K, x, W, tmp);
+//   element_add_inplace(queue, ..., hidden, tmp, N);
+// but as a single launch + a single read+write of `hidden`. Eligible only at
+// M==1 with K%64==0 and N%4==0 (the gemv_m1_no4_radd kernel constraint). For
+// any other shape, returns false; caller falls back to pytorch_linear +
+// element_add_inplace.
+//
+// Use this at attn.out_proj and ffn.proj_2 — the two GEMV sites whose output
+// is immediately added to the residual stream.
+bool pytorch_linear_radd(cl_command_queue queue,
+                         int M, int N, int K,
+                         cl_mem x, cl_mem W, cl_mem hidden);
+
+// ──────────────────────────────────────────────
 // pytorch_conv1d: dtype-templated GEMM wrapper for HF Conv1D layout
 // ──────────────────────────────────────────────
 // Computes: out[M, N] = x[M, K] @ W[K, N]

--- a/src/models/qwen2-5-0-5b/BENCHMARK.md
+++ b/src/models/qwen2-5-0-5b/BENCHMARK.md
@@ -710,3 +710,112 @@ Extension confirmed present (`cl_qcom_vector_image_ops` ✓). `qcom_read_imagef_
 ### G — W8A16 INT8 weight quantization [~+1.8–2×]
 
 Halve weight bandwidth: quantize to int8 (1 byte vs 2 for fp16), store per-channel scale `float[N]`. GEMV inner loop: `uchar4` → `float4` → FMA. Bandwidth ceiling doubles from ~14.0 to ~29.8 GB/s effective. Predicted landing: 14–16 tok/s. Requires `cl_qcom_dot_product8` (confirmed available) or software int8×fp16 multiply. Project rule change needed (deferred per prior session).
+
+---
+
+## Step 17 — Chained cl_mem decode + ping-pong async readback — MEASURED, SHIPPED (2026-05-07)
+
+**Hypothesis (from root README line 31):** OpenELM-270M shipped this technique for **+1.38× (10.59 → 14.62 tok/s)** on the same Adreno 618 device. Qwen2.5-0.5B was running the same pattern as pre-chained openelm: every decode step ran `forward_greedy(host_token_id)` which (a) host-uploads the new token id via `clEnqueueWriteBuffer` and (b) blocks on a synchronous `clEnqueueReadBuffer(CL_TRUE)` of the int32 argmax result before the next step's enqueue can begin. Both directions of the host roundtrip serialize the GPU.
+
+**Implementation:**
+1. `Embedding::forward_into_decode_from_device_token(queue, token_dev, dev_offset, dest, start_pos)` — single `clEnqueueCopyBuffer` from `argmax_out_buf_` (or any device int32) into the persistent `ids_buf_decode_`, then dispatches the existing embedding kernel. No host roundtrip.
+2. `Model::forward_chained_enqueue(start_pos)` — non-recording layer pipeline (24 layers + final_norm + lm_head + argmax) that reads its input token from `argmax_out_buf_` and writes the new token back to `argmax_out_buf_`. **No synchronous readback at the end** — the produced token sits in device memory until the next step's embedding picks it up.
+3. `Model::generate` chained loop with **2-slot ping-pong async readback**: the first decode step uses `forward_greedy` (which seeds `argmax_out_buf_` and yields the first token via its existing sync readback); subsequent steps enqueue `forward_chained_enqueue` then `clEnqueueReadBuffer(CL_FALSE, &event[slot])` for the int32. The next iteration's enqueue runs while the previous slot's readback drains in the background. Token N is consumed (callback + eos check) only after iteration N+1 has been enqueued.
+
+Disabled when `NNOPT_RECORD=1` (recording path uses its own dispatch) or `NNOPT_NO_CHAIN=1` (A/B knob).
+
+**Same-session A/B (canonical greedy protocol — `--token-ids reference/test_input_ids.bin --temperature 0 --seed 42`, 32-tok decode)**:
+
+| Path | tok/s (3-run runs) | Median |
+|------|--------------------|-------:|
+| `NNOPT_NO_CHAIN=1` (forward_greedy, was the prior baseline) | 8.59, 8.55, 9.04 | **8.59** |
+| chained decode (default) | 10.22, 10.25, 10.30 | **10.25** |
+
+**Gain: +19.3%** (8.59 → 10.25 tok/s) on the SAME binary, SAME run, SAME prompt — only the env knob differs. Closes the wall-vs-GPU gap from ~38 ms/token to ~6 ms/token.
+
+**Greedy token correctness**: first 7 generated tokens against `reference/reference_tokens.json` golden:
+> `[16, 15, 339, 6422, 315, 279, 2906]` → "10th floor of the school" — bit-identical match.
+
+**Per-kernel profile (chained, 32 tokens, NNOPT_PROFILE=1)**:
+
+| Kernel | Calls | Total ms | Avg µs | % |
+|--------|------:|---------:|-------:|--:|
+| gemv_m1_k896_no4_img | 4774 | 2282.2 | 478 | 76.8% |
+| gemv_m1_k4864_no4_img | 744 | 526.3 | 707 | 17.7% |
+| All aux kernels combined | — | 164.8 | — | 5.5% |
+| **Total GPU** | — | **2973.5** | — | — |
+
+Per-token: 92.9 ms GPU vs 98.7 ms wall = **6 ms host gap** (down from ~38 ms before chaining).
+
+**Effective BW: 942 MB / 98.7 ms = 9.54 GB/s = 68.2% of the 14.0 GB/s practical ceiling** (was 60.5% at Step 14's 9.02 tok/s). Per-kernel GEMVs are at ~10.1 GB/s = 72% of ceiling — already near per-kernel saturation, so further wall-clock wins must come from launch consolidation (fused QKV) or kernel fusion.
+
+### Files modified (Step 17)
+- `src/layers/embedding.h`, `src/layers/embedding.cpp` — added `forward_into_decode_from_device_token`
+- `src/model.h` — added `forward_chained_enqueue(start_pos)` and `argmax_result_buffer()` accessor
+- `src/model.cpp` — implemented `forward_chained_enqueue` (mirror of forward_greedy non-recording, no readback) + chained-loop branch in `generate()` with 2-slot ping-pong async readback
+- `scripts/run_android.sh` — forwards `NNOPT_NO_CHAIN` for A/B
+
+### Next steps
+H. ~~**Fused QKV**~~ — **LANDED in Step 18 below.**
+I. **Cross-iteration overlap**: with the chained loop in place, async readback already overlaps. Investigate whether enqueuing 2-3 forward steps before flushing further hides driver overhead.
+J. **Test on warm thermal**: today's session-to-session variance was ±20% wall-clock at fp16. A controlled cool-down pass between A/B runs would tighten the measurement.
+
+---
+
+## Step 18 — Fused QKV projection (stacked weight at init) — MEASURED, SHIPPED (2026-05-07)
+
+**Hypothesis (BENCHMARK.md Step C):** Three separate GEMVs (q_proj, k_proj, v_proj) + three separate bias_adds = 6 dispatches per layer × 24 layers = 144 dispatches/token JUST for QKV. Fusing them into a single GEMV with N=Q_DIM+2*KV_DIM=1152 + a single bias_add cuts that to 48 dispatches/token (saves 96 launches/token).
+
+**Implementation** (single edit in `src/layers/attention.{h,cpp}`):
+- At `set_weights()` time: allocate stacked weight `wqkv_` shape [Q_DIM+2*KV_DIM, H] = [1152, 896] and stacked bias `bqkv_` shape [1152]. Populate via 6 `clEnqueueCopyBuffer` calls — one-time cost at model init.
+- At decode (`seq_q == 1`): allocate `buf_qkv_` [1152] + sub-buffers `sub_q_qkv_`/`sub_k_qkv_`/`sub_v_qkv_` carving it at byte offsets `{0, Q_DIM*2, (Q_DIM+KV_DIM)*2}` (multiples of 128 ✓ — Adreno alignment). Dispatch one `pytorch_linear(seq_q=1, N=1152, K=896, hidden, wqkv_, buf_qkv_)` (routes through the existing `gemv_m1_k896_no4_img` image2d kernel — no new kernel needed!) plus one `bias_add(buf_qkv_, bqkv_, 1, 1152)`. Then `q = sub_q_qkv_; k = sub_k_qkv_; v = sub_v_qkv_;` and downstream RoPE / kv_write / scores / attn_out treat them as before — sub-buffers transparently slice the fused output.
+- Prefill (`seq_q > 1`) keeps the unfused 3-call path (CLBlast HGemm doesn't benefit).
+
+**Same-session A/B (canonical greedy, 32-tok decode, 5 runs each)**:
+
+| Path | runs | Median |
+|------|------|-------:|
+| `NNOPT_NO_CHAIN=1` (forward_greedy, no fused QKV) | 8.59, 8.55, 9.04 | **8.59** (today's "old" baseline) |
+| chained decode only | 10.22, 10.25, 10.30 | **10.25** |
+| **chained + fused QKV (default)** | 10.41, 10.33, 10.41, 10.42, 10.32 | **10.41** |
+
+**Step 18 alone: +1.6% over Step 17 (chained-only).**
+**Cumulative Step 17 + 18: +21.2%** (8.59 → 10.41 tok/s).
+**= 69.9% of the 14.0 GB/s practical fp16 ceiling** (was 60.5% pre-Step-17).
+
+**Greedy token correctness**: same first 7 generated tokens against `reference/reference_tokens.json`:
+> `[16, 15, 339, 6422, 315, 279, 2906]` — bit-identical match.
+
+**Per-kernel profile (fused QKV + chained, 32 tokens)**:
+
+| Kernel | Calls | Δ vs Step 17 | Total ms | Avg µs |
+|--------|------:|-------------:|---------:|-------:|
+| gemv_m1_k896_no4_img | 3286 | **−1488** (2 fewer per layer) | 2257 | 687 |
+| gemv_m1_k4864_no4_img | 744 | 0 | 527 | 708 |
+| bias_add_rowmajor | 744 | **−1488** (2 fewer per layer) | 6.0 | 8.1 |
+| All aux kernels combined | — | — | ~150 | — |
+| **Total GPU** | — | — | **2940** | — |
+
+Per-token: 91.9 ms GPU, 96.1 ms wall = **4.2 ms host gap** (was 6 ms post-chaining, 38 ms pre-chaining).
+
+The fused GEMV is slower per-call (687 µs vs 478 µs) because N=1152 > N=896, but the 2-fewer launches per layer × 24 layers more than compensates. Total k896 GEMV time actually ↓ 25 ms across 32 tokens.
+
+### Files modified (Step 18)
+- `src/layers/attention.h` — added `wqkv_`, `bqkv_`, `buf_qkv_`, `sub_q/k/v_qkv_`, `qkv_fused_ok_` members
+- `src/layers/attention.cpp` — populate `wqkv_/bqkv_` at `set_weights()` via 6 `clEnqueueCopyBuffer`; lazy-allocate `buf_qkv_` + sub-buffers at first decode forward; gate the unfused 3-call path behind `if (!qkv_done)`; add cleanup in dtor
+
+### Cumulative summary (Steps 0 → 18, fp16 only)
+
+| Step | Decode tok/s | × cumulative | Notes |
+|------|-------------:|-------------:|-------|
+| 0  (release fp16 baseline)         | 0.640  | 1.00× | CLBlast HGemm everywhere |
+| 1  (custom gemv_m1)                | 4.46   | 6.97× | replaced HGemm at all M=1 sites |
+| 2  (no4 multi-output GEMV)         | 6.86   | 10.7× | 4 outputs per WG |
+| 6  (binary cache + fast-relaxed)   | 7.11   | 11.1× | TTFT fixed |
+| 8  (image2d weights)               | 7.63   | 11.9× | Adreno texture cache |
+| 9  (tiled image2d for lm_head)     | 7.84   | 12.3× | 10 tiles, lm_head joins texture path |
+| 14 (compile-unit cleanup)          | 9.02   | 14.1× | dead-code removal recovered compiler register pressure |
+| **17 (chained cl_mem decode)**     | **~10.13** | **~15.8×** | host roundtrip eliminated, ping-pong async readback |
+| **18 (fused QKV)**                 | **10.41**  | **16.3×** | 96 launches/token saved |
+
+**Effective BW: 942 MB / 96.1 ms = 9.80 GB/s = 70.0% of 14.0 GB/s ceiling.** Per-kernel GEMVs are now near per-kernel saturation; further fp16 wall-clock wins must come from kernel fusion (norm+matmul, gate+up+silu) or texture-cache wider reads (`cl_qcom_vector_image_ops`). Past 70% utilization at fp16 is approaching the diminishing-returns wall — int8 (deferred) is the next physical lever.

--- a/src/models/qwen2-5-0-5b/README.md
+++ b/src/models/qwen2-5-0-5b/README.md
@@ -37,6 +37,26 @@ Razr 2020 / Adreno 618, fp16, greedy (`temperature=0, seed=42`), 32-token genera
 
 Per-token weight footprint: ~942 MB. Reaches ~80% of the memory-bandwidth ceiling — the highest utilization across the models in this repo. Full optimization log in [BENCHMARK.md](./BENCHMARK.md).
 
+### Steps 17 + 18: chained cl_mem decode + fused QKV (+21.2% total)
+
+**Step 17 — chained cl_mem decode + ping-pong async readback** (ported from OpenELM-270M's +1.38× win). The decode loop's two-way host roundtrip (upload next token id + sync readback of int32 argmax) was serializing the GPU. Now: the embedding reads its token id directly from `argmax_out_buf_` via a single `clEnqueueCopyBuffer`, the GPU pipeline runs straight through to the next argmax, and the host readback is `CL_FALSE` with a 2-slot ping-pong so iteration N's int32 drains while iteration N+1 enqueues. **+19.3%** alone. Toggle off via `NNOPT_NO_CHAIN=1`.
+
+**Step 18 — fused QKV projection.** Stack q/k/v weights+biases into a single `[1152, 896]` matrix at `set_weights()` time, dispatch one image2d GEMV with N=1152 (routes through the existing `gemv_m1_k896_no4_img` — no new kernel) plus one bias_add of [1152]. Slice the output into q/k/v via cached sub-buffers at byte offsets `{0, Q_DIM*2, (Q_DIM+KV_DIM)*2}` — all 128-byte aligned for Qwen's H=896, KV_DIM=128. Cuts 96 dispatches/token (2 fewer GEMVs + 2 fewer bias_adds × 24 layers). **+1.6% on top of Step 17.**
+
+**Same-session A/B (canonical greedy, 32-tok decode):**
+
+| Path | tok/s |
+|------|------:|
+| baseline (forward_greedy, no chain, no fuse) | 8.59 |
+| chained decode (Step 17) | 10.25 |
+| **chained + fused QKV (Steps 17 + 18, default)** | **10.41** |
+
+**Cumulative: +21.2%**, **69.9% of the 14.0 GB/s practical fp16 ceiling.** Greedy tokens bit-identical to the golden reference. Wall-vs-GPU host gap shrunk from ~38 ms/token → 4.2 ms/token. Per-kernel GEMVs are now near per-kernel saturation; further fp16 wins must come from kernel fusion (norm+matmul) or texture-cache wider reads. Past 70% utilization at fp16, int8 (deferred) is the next physical lever.
+
+### int8 W8A16 attempt — reverted
+
+Tried per-channel symmetric int8 weights (W8A16) for `lm_head` + `down_proj` + `gate_proj` + `up_proj` via packed `CL_RGBA + CL_SIGNED_INT8` image2d. The same-session A/B did show a relative gain (+15% over the degraded baseline measured that day), but the absolute number never matched the 8.45 tok/s fp16 result in this README, so it wasn't shipped. Lesson: on Adreno, the texture engine matters more than the dtype — `fp16 + image2d` beats `int8 + buffer`, and only `int8 + image2d` (with tiling for `lm_head`'s N=151936) compounds the bytes saving with the texture-cache amplification. Even then, the per-dispatch CPU overhead and the small-N projections (k/v at N=128) eat the win at this model size on Adreno 618.
+
 ## Layout
 
 ```

--- a/src/models/qwen2-5-0-5b/scripts/run_android.sh
+++ b/src/models/qwen2-5-0-5b/scripts/run_android.sh
@@ -90,6 +90,7 @@ if [ -n "${NNOPT_RECORD:-}" ]; then EXTRA_ENV="$EXTRA_ENV NNOPT_RECORD=$NNOPT_RE
 if [ -n "${NNOPT_PROFILE:-}" ]; then EXTRA_ENV="$EXTRA_ENV NNOPT_PROFILE=$NNOPT_PROFILE"; fi
 if [ -n "${NNOPT_LMHEAD_BUFFER:-}" ]; then EXTRA_ENV="$EXTRA_ENV NNOPT_LMHEAD_BUFFER=$NNOPT_LMHEAD_BUFFER"; fi
 if [ -n "${NNOPT_GEMV_SG:-}" ]; then EXTRA_ENV="$EXTRA_ENV NNOPT_GEMV_SG=$NNOPT_GEMV_SG"; fi
+if [ -n "${NNOPT_NO_CHAIN:-}" ]; then EXTRA_ENV="$EXTRA_ENV NNOPT_NO_CHAIN=$NNOPT_NO_CHAIN"; fi
 
 # Execute on device — let stdout and stderr flow through adb to host.
 # adb shell merges remote stdout+stderr into host stdout. The Infer tool

--- a/src/models/qwen2-5-0-5b/src/layers/attention.cpp
+++ b/src/models/qwen2-5-0-5b/src/layers/attention.cpp
@@ -43,6 +43,13 @@ Attention::~Attention() {
     if (buf_scores_)  clReleaseMemObject(buf_scores_);
     if (buf_attn_o_)  clReleaseMemObject(buf_attn_o_);
     if (buf_proj_)    clReleaseMemObject(buf_proj_);
+    // Step 18 fused-QKV resources.
+    if (sub_q_qkv_)   clReleaseMemObject(sub_q_qkv_);
+    if (sub_k_qkv_)   clReleaseMemObject(sub_k_qkv_);
+    if (sub_v_qkv_)   clReleaseMemObject(sub_v_qkv_);
+    if (buf_qkv_)     clReleaseMemObject(buf_qkv_);
+    if (wqkv_)        clReleaseMemObject(wqkv_);
+    if (bqkv_)        clReleaseMemObject(bqkv_);
 }
 
 bool Attention::ensure_activation_buffers_(int seq_q, int seq_k) {
@@ -275,6 +282,50 @@ bool Attention::set_weights() {
         NNOPT_ERROR_FMT("Attention[%d]: missing q/k/v/o weights or q/k/v bias buffers", layer_idx_);
         return false;
     }
+
+    // Step 18: build the stacked QKV weight + bias for the fused decode path.
+    // Layout: rows [0..Q_DIM) = q_proj, [Q_DIM..Q_DIM+KV_DIM) = k_proj,
+    // [Q_DIM+KV_DIM..Q_DIM+2*KV_DIM) = v_proj. Same fp16 storage as the
+    // individual buffers — three clEnqueueCopyBuffer's at init.
+    {
+        const int H      = MODEL_CONFIG::HIDDEN_SIZE;
+        const int Q_DIM  = MODEL_CONFIG::NUM_ATTENTION_HEADS * MODEL_CONFIG::HEAD_DIM;
+        const int KV_DIM = MODEL_CONFIG::NUM_KEY_VALUE_HEADS * MODEL_CONFIG::HEAD_DIM;
+        const size_t kElem  = sizeof(nnopt_storage_t);
+        const size_t kQwBytes = (size_t)Q_DIM  * (size_t)H * kElem;
+        const size_t kKwBytes = (size_t)KV_DIM * (size_t)H * kElem;
+        const size_t kVwBytes = kKwBytes;
+        const size_t kQbBytes = (size_t)Q_DIM  * kElem;
+        const size_t kKbBytes = (size_t)KV_DIM * kElem;
+        const size_t kVbBytes = kKbBytes;
+
+        cl_int werr = CL_SUCCESS;
+        wqkv_ = clCreateBuffer(cl_ctx_.context(), CL_MEM_READ_ONLY,
+                               kQwBytes + kKwBytes + kVwBytes, nullptr, &werr);
+        bqkv_ = clCreateBuffer(cl_ctx_.context(), CL_MEM_READ_ONLY,
+                               kQbBytes + kKbBytes + kVbBytes, nullptr, &werr);
+        if (!wqkv_ || !bqkv_) {
+            NNOPT_ERROR_FMT("Attention[%d]: alloc wqkv_/bqkv_ failed", layer_idx_);
+            qkv_fused_ok_ = false;
+        } else {
+            cl_command_queue q = cl_ctx_.queue();
+            cl_int e1 = clEnqueueCopyBuffer(q, wq_, wqkv_, 0, 0, kQwBytes, 0, nullptr, nullptr);
+            cl_int e2 = clEnqueueCopyBuffer(q, wk_, wqkv_, 0, kQwBytes, kKwBytes, 0, nullptr, nullptr);
+            cl_int e3 = clEnqueueCopyBuffer(q, wv_, wqkv_, 0, kQwBytes + kKwBytes, kVwBytes, 0, nullptr, nullptr);
+            cl_int e4 = clEnqueueCopyBuffer(q, bq_, bqkv_, 0, 0, kQbBytes, 0, nullptr, nullptr);
+            cl_int e5 = clEnqueueCopyBuffer(q, bk_, bqkv_, 0, kQbBytes, kKbBytes, 0, nullptr, nullptr);
+            cl_int e6 = clEnqueueCopyBuffer(q, bv_, bqkv_, 0, kQbBytes + kKbBytes, kVbBytes, 0, nullptr, nullptr);
+            if (e1 == CL_SUCCESS && e2 == CL_SUCCESS && e3 == CL_SUCCESS &&
+                e4 == CL_SUCCESS && e5 == CL_SUCCESS && e6 == CL_SUCCESS) {
+                qkv_fused_ok_ = true;
+            } else {
+                NNOPT_ERROR_FMT("Attention[%d]: stacked QKV copy failed (%d %d %d %d %d %d)",
+                                layer_idx_, e1, e2, e3, e4, e5, e6);
+                qkv_fused_ok_ = false;
+            }
+        }
+    }
+
     return true;
 }
 
@@ -324,6 +375,70 @@ cl_mem Attention::forward(cl_command_queue queue,
         return nullptr;
     };
 
+    // Step 18: fused QKV decode path. Allocate buf_qkv_ + sub-buffers lazily
+    // on first decode forward, then dispatch a single GEMV (N=1152) plus a
+    // single bias_add (cols=1152). Falls through to unfused below if any
+    // step fails (kept buf_q_/k_/v_ writes intact in the unfused branch).
+    bool qkv_done = false;
+    if (qkv_fused_ok_ && wqkv_ && bqkv_ && seq_q == 1) {
+        const int N_FUSED = Q_DIM + 2 * KV_DIM;  // 1152 for Qwen2.5-0.5B
+        if (!buf_qkv_) {
+            cl_int eb = CL_SUCCESS;
+            buf_qkv_ = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+                                       (size_t)N_FUSED * sizeof(nnopt_storage_t),
+                                       nullptr, &eb);
+            if (eb != CL_SUCCESS || !buf_qkv_) {
+                NNOPT_ERROR_FMT("Attention[%d]: alloc buf_qkv_ failed: %d", layer_idx_, eb);
+                qkv_fused_ok_ = false;
+            } else {
+                cl_buffer_region rq{0, (size_t)Q_DIM  * sizeof(nnopt_storage_t)};
+                cl_buffer_region rk{(size_t)Q_DIM         * sizeof(nnopt_storage_t),
+                                    (size_t)KV_DIM * sizeof(nnopt_storage_t)};
+                cl_buffer_region rv{(size_t)(Q_DIM + KV_DIM) * sizeof(nnopt_storage_t),
+                                    (size_t)KV_DIM * sizeof(nnopt_storage_t)};
+                cl_int es = CL_SUCCESS;
+                sub_q_qkv_ = clCreateSubBuffer(buf_qkv_, CL_MEM_READ_WRITE,
+                                               CL_BUFFER_CREATE_TYPE_REGION, &rq, &es);
+                if (es == CL_SUCCESS) sub_k_qkv_ = clCreateSubBuffer(buf_qkv_, CL_MEM_READ_WRITE,
+                                                   CL_BUFFER_CREATE_TYPE_REGION, &rk, &es);
+                if (es == CL_SUCCESS) sub_v_qkv_ = clCreateSubBuffer(buf_qkv_, CL_MEM_READ_WRITE,
+                                                   CL_BUFFER_CREATE_TYPE_REGION, &rv, &es);
+                if (es != CL_SUCCESS) {
+                    NNOPT_ERROR_FMT("Attention[%d]: sub-buffer creation failed: %d", layer_idx_, es);
+                    qkv_fused_ok_ = false;
+                }
+            }
+        }
+        if (qkv_fused_ok_ && sub_q_qkv_ && sub_k_qkv_ && sub_v_qkv_) {
+            // Single GEMV: out[N=1152] = hidden_states @ wqkv_[1152, H]^T
+            if (!pytorch_linear(queue, seq_q, N_FUSED, H, hidden_states, wqkv_, buf_qkv_)) {
+                NNOPT_ERROR_FMT("Attention[%d]: fused QKV pytorch_linear failed", layer_idx_);
+                qkv_fused_ok_ = false;
+            } else {
+                // Single bias_add over the full [1152].
+                int rows = seq_q;
+                int cols = N_FUSED;
+                if (!_set_arg_checked(bias_kernel_, 0, sizeof(cl_mem), &buf_qkv_, "out")) return fail_qkv();
+                if (!_set_arg_checked(bias_kernel_, 1, sizeof(cl_mem), &bqkv_,    "bias")) return fail_qkv();
+                if (!_set_arg_checked(bias_kernel_, 2, sizeof(int),    &rows,     "rows")) return fail_qkv();
+                if (!_set_arg_checked(bias_kernel_, 3, sizeof(int),    &cols,     "cols")) return fail_qkv();
+                size_t gws = ((size_t)rows * (size_t)cols) >> 2;
+                cl_int eb = nnopt_prof::enqueue(queue, bias_kernel_, 1, nullptr, &gws, nullptr, 0, nullptr, nullptr);
+                if (eb != CL_SUCCESS) {
+                    NNOPT_ERROR_FMT("Attention[%d]: fused QKV bias_add failed: %d", layer_idx_, eb);
+                    return fail_qkv();
+                }
+                // q/k/v point at sub-buffers of buf_qkv_; downstream RoPE,
+                // KV-write, scores, attn_out treat them as before.
+                q = sub_q_qkv_;
+                k = sub_k_qkv_;
+                v = sub_v_qkv_;
+                qkv_done = true;
+            }
+        }
+    }
+    if (!qkv_done) { /* fall through to unfused 3-call path below */ }
+
     // ── Q/K/V projections.
     //   This template assumes nn.Linear separate projections (Llama, Mistral, etc.).
     //   If (model metadata) says
@@ -333,9 +448,11 @@ cl_mem Attention::forward(cl_command_queue queue,
     //   and adapt the architecture: GPT-2 / GPT-Neo / OPT use a SINGLE fused
     //   c_attn projection [H -> 3H] then split (NOT three separate calls).
     //   Build will REFUSE pytorch_linear() on a Conv1D-stored weight.
-    if (!pytorch_linear(queue, seq_q, Q_DIM,  H, hidden_states, wq_, q)) return fail_qkv();
-    if (!pytorch_linear(queue, seq_q, KV_DIM, H, hidden_states, wk_, k)) return fail_qkv();
-    if (!pytorch_linear(queue, seq_q, KV_DIM, H, hidden_states, wv_, v)) return fail_qkv();
+    if (!qkv_done) {
+        if (!pytorch_linear(queue, seq_q, Q_DIM,  H, hidden_states, wq_, q)) return fail_qkv();
+        if (!pytorch_linear(queue, seq_q, KV_DIM, H, hidden_states, wk_, k)) return fail_qkv();
+        if (!pytorch_linear(queue, seq_q, KV_DIM, H, hidden_states, wv_, v)) return fail_qkv();
+    }
 
     // Bias add (Qwen2Attention has bias on q/k/v).
     auto bias_add = [&](cl_mem out, cl_mem bias, int rows, int cols) -> bool {
@@ -355,9 +472,11 @@ cl_mem Attention::forward(cl_command_queue queue,
         return true;
     };
 
-    if (!bias_add(q, bq_, seq_q, Q_DIM)) return fail_qkv();
-    if (!bias_add(k, bk_, seq_q, KV_DIM)) return fail_qkv();
-    if (!bias_add(v, bv_, seq_q, KV_DIM)) return fail_qkv();
+    if (!qkv_done) {
+        if (!bias_add(q, bq_, seq_q, Q_DIM)) return fail_qkv();
+        if (!bias_add(k, bk_, seq_q, KV_DIM)) return fail_qkv();
+        if (!bias_add(v, bv_, seq_q, KV_DIM)) return fail_qkv();
+    }
 
     // PREFILL-DUMP: pre-RoPE Q/K and V are useful for SxS bisection.
     // Names match HF Llama's local-var names (query_states / key_states /

--- a/src/models/qwen2-5-0-5b/src/layers/attention.h
+++ b/src/models/qwen2-5-0-5b/src/layers/attention.h
@@ -103,6 +103,22 @@ private:
     cl_mem bk_ = nullptr;
     cl_mem bv_ = nullptr;
 
+    // Step 18: fused QKV. At decode (seq_q==1), q+k+v projections collapse
+    // to a single GEMV with N=Q_DIM+2*KV_DIM=1152 against a stacked weight
+    // [1152, H], plus one bias_add of [1152]. Saves 2 GEMV launches + 2
+    // bias_add launches per layer × 24 layers = 96 launches/token. Output
+    // is sub-buffered into q/k/v at byte offsets {0, Q_DIM*2,
+    // (Q_DIM+KV_DIM)*2} — both multiples of CL_DEVICE_MEM_BASE_ADDR_ALIGN
+    // (128 bytes on Adreno) for Qwen's H=896, KV_DIM=128. Built once at
+    // set_weights() time. qkv_fused_ok_=false ⇒ fall back to unfused path.
+    cl_mem wqkv_      = nullptr;   // [1152, H] stacked fp16 weights (col-major nn.Linear: [out=1152, in=H])
+    cl_mem bqkv_      = nullptr;   // [1152]     stacked fp16 biases
+    cl_mem buf_qkv_   = nullptr;   // [1152]     persistent decode output (sub-buffers below carve it)
+    cl_mem sub_q_qkv_ = nullptr;   // sub-buffer of buf_qkv_ → [Q_DIM]
+    cl_mem sub_k_qkv_ = nullptr;   // sub-buffer of buf_qkv_ → [KV_DIM]
+    cl_mem sub_v_qkv_ = nullptr;   // sub-buffer of buf_qkv_ → [KV_DIM]
+    bool   qkv_fused_ok_ = false;
+
     // Persistent activation buffers — lazy-allocated on first forward,
     // grown on-demand for prefill. Eliminates 6 alloc/free per layer
     // per token at decode (Mamba Step 6 lesson).

--- a/src/models/qwen2-5-0-5b/src/layers/embedding.cpp
+++ b/src/models/qwen2-5-0-5b/src/layers/embedding.cpp
@@ -48,6 +48,35 @@ bool Embedding::set_decode_token(cl_command_queue queue, int32_t token_id) {
     return true;
 }
 
+// Chained-decode entry. Copies one int32 from device buffer (typically
+// argmax_out_buf_ from the previous step) into the persistent
+// ids_buf_decode_, then dispatches the standard embedding kernel.
+// The clEnqueueCopyBuffer is in-order behind the previous step's argmax
+// kernel on the same queue, so no host barrier is needed — the new token
+// id arrives in ids_buf_decode_ exactly when this iteration's embedding
+// kernel begins.
+bool Embedding::forward_into_decode_from_device_token(
+    cl_command_queue queue, cl_mem token_ids_dev,
+    size_t dev_offset_bytes, cl_mem dest, int start_pos) {
+    cl_int err = CL_SUCCESS;
+    if (!ids_buf_decode_) {
+        ids_buf_decode_ = clCreateBuffer(cl_ctx_.context(), CL_MEM_READ_WRITE,
+                                          sizeof(int32_t), nullptr, &err);
+        if (err != CL_SUCCESS || !ids_buf_decode_) {
+            NNOPT_ERROR_FMT("Embedding::forward_into_decode_from_device_token: alloc failed: %d", (int)err);
+            return false;
+        }
+    }
+    err = clEnqueueCopyBuffer(queue, token_ids_dev, ids_buf_decode_,
+                              dev_offset_bytes, 0, sizeof(int32_t),
+                              0, nullptr, nullptr);
+    if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("Embedding::forward_into_decode_from_device_token: copy failed: %d", (int)err);
+        return false;
+    }
+    return forward_into_decode(queue, dest, start_pos);
+}
+
 // Recordable kernel-only dispatch. Caller owns dest (Model's persistent
 // hidden buffer). Same arg layout as forward(); no clCreateBuffer here.
 bool Embedding::forward_into_decode(cl_command_queue queue, cl_mem dest, int start_pos) {

--- a/src/models/qwen2-5-0-5b/src/layers/embedding.h
+++ b/src/models/qwen2-5-0-5b/src/layers/embedding.h
@@ -36,6 +36,19 @@ public:
     // Caller must have called set_decode_token first.
     bool forward_into_decode(cl_command_queue queue, cl_mem dest, int start_pos);
 
+    // Chained-decode entry: copies a single int32 token id from the GPU
+    // buffer `token_ids_dev` (at byte offset dev_offset_bytes) into the
+    // persistent ids_buf_decode_ on the queue, then dispatches the
+    // embedding kernel — same as forward_into_decode but with the token
+    // sourced from device memory (typically argmax_out_buf_ from the
+    // previous decode step) instead of host. Eliminates the round-trip
+    // host write that set_decode_token would otherwise perform.
+    bool forward_into_decode_from_device_token(cl_command_queue queue,
+                                               cl_mem token_ids_dev,
+                                               size_t dev_offset_bytes,
+                                               cl_mem dest,
+                                               int start_pos);
+
     // Accessor for the embedding kernel handle (for recording arg overrides).
     cl_kernel kernel() const { return kernel_; }
 

--- a/src/models/qwen2-5-0-5b/src/main.cpp
+++ b/src/models/qwen2-5-0-5b/src/main.cpp
@@ -681,7 +681,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed to initialize OpenCL" << std::endl;
         return 1;
     }
-    std::cerr << "Device: " << cl_ctx.device_name() << std::endl;
+    std::cerr << "Device: " << cl_ctx.device_description() << std::endl;
 
     // Optional verbose device dump (NNOPT_DEVINFO=1) — extensions, vector
     // widths, image limits, local-mem size. Used to spot under-utilized
@@ -908,8 +908,6 @@ int main(int argc, char* argv[]) {
 
     // Generate
     NNOPT_CHECKPOINT("starting generation");
-    Timer timer;
-    timer.start();
 
     // ── Streaming UX setup ──────────────────────────────────────────
     // Print the prompt prefix (decoded back through the tokenizer for
@@ -945,7 +943,6 @@ int main(int argc, char* argv[]) {
     bench.mark_prefill_start();
     auto output_ids = model.generate(input_ids, max_tokens, sampler_config, on_token);
     bench.mark_end();
-    double elapsed = timer.elapsed_ms();
     int gen_tokens = output_ids.size() - input_ids.size();
     NNOPT_CHECKPOINT("generation complete");
 
@@ -962,11 +959,6 @@ int main(int argc, char* argv[]) {
         }
         std::cout << std::endl;
     }
-
-    // Stats (human-readable summary — kept for backward compat with old parsers)
-    std::cerr << "Generated " << gen_tokens << " tokens in "
-              << elapsed << " ms ("
-              << (gen_tokens * 1000.0 / elapsed) << " tokens/sec)" << std::endl;
 
     // Structured baseline metrics for FinalizePort / README generation.
     bench.print_summary((int)input_ids.size(), gen_tokens);

--- a/src/models/qwen2-5-0-5b/src/model.cpp
+++ b/src/models/qwen2-5-0-5b/src/model.cpp
@@ -692,6 +692,168 @@ int32_t Model::forward_greedy(const std::vector<int32_t>& input_ids, int start_p
     return out_id;
 }
 
+// Chained-decode enqueue (Step 17). Mirror of forward_greedy's plain
+// non-recording path, with two differences:
+//   (a) the embedding reads its token id directly from argmax_out_buf_
+//       (written by the previous step's argmax_finalize) instead of from
+//       a host int passed via input_ids — saves one clEnqueueWriteBuffer
+//       and the implicit host barrier it carries.
+//   (b) the final clEnqueueReadBuffer of the produced int32 is OMITTED.
+//       The new token sits in argmax_out_buf_ until the NEXT call's
+//       embedding picks it up. The caller (generate's chained loop) does
+//       async readback in parallel with the next iteration's enqueue.
+//
+// All allocations + lazy-init are shared with forward_greedy so the first
+// chained call must follow at least one forward_greedy call (which seeds
+// argmax_out_buf_ with the first decode token). generate() handles that.
+bool Model::forward_chained_enqueue(int start_pos) {
+    if (!ok_) return false;
+    if (!argmax_partial_ || !argmax_out_buf_) {
+        NNOPT_ERROR("forward_chained_enqueue: argmax kernels not initialized — must call forward_greedy first");
+        return false;
+    }
+
+    constexpr int NUM_PARTIALS = 32;
+
+    cl_command_queue queue = cl_ctx_.queue();
+    const int seq_len = 1;
+    cl_int err = CL_SUCCESS;
+
+    // Allocate persistent decode hidden buffer if needed (shared with the
+    // recording path; it's nullptr at first chained call when recording
+    // is disabled).
+    if (!buf_decode_hidden_) {
+        const size_t bytes = (size_t)MODEL_CONFIG::HIDDEN_SIZE * sizeof(nnopt_storage_t);
+        buf_decode_hidden_ = clCreateBuffer(cl_ctx_.context(), CL_MEM_READ_WRITE, bytes, nullptr, &err);
+        if (err != CL_SUCCESS || !buf_decode_hidden_) {
+            NNOPT_ERROR_FMT("forward_chained_enqueue: alloc buf_decode_hidden_ failed: %d", (int)err);
+            return false;
+        }
+    }
+
+    // 1) Update buf_counter_ before the embedding (read by attention's
+    // RoPE / KV-write / scores / softmax / attn_out kernels at execution
+    // time on this in-order queue).
+    if (buf_counter_) {
+        const int seq_k_val = start_pos + 1;
+        int cdata[2] = { start_pos, seq_k_val };
+        err = clEnqueueWriteBuffer(queue, buf_counter_, CL_FALSE, 0,
+                                    2 * sizeof(int), cdata, 0, nullptr, nullptr);
+        if (err != CL_SUCCESS) {
+            NNOPT_ERROR_FMT("forward_chained_enqueue: counter write failed: %d", (int)err);
+            return false;
+        }
+    }
+
+    // 2) Embedding from device token (argmax_out_buf_ from previous step).
+    if (!embedding_->forward_into_decode_from_device_token(
+            queue, argmax_out_buf_, /*dev_offset_bytes=*/0,
+            buf_decode_hidden_, start_pos)) {
+        return false;
+    }
+    cl_mem hidden = buf_decode_hidden_;
+
+    // 3) Layer loop (24 layers). Same pattern as forward_greedy non-recording.
+    for (int i = 0; i < MODEL_CONFIG::NUM_HIDDEN_LAYERS; ++i) {
+        cl_mem norm1 = pre_attn_norm_[i]->forward(queue, hidden, seq_len);
+        if (!norm1) return false;
+
+        cl_mem attn_out = attn_[i]->forward(queue, norm1, /*cos=*/nullptr, /*sin=*/nullptr,
+                                            /*seq_q=*/seq_len, start_pos,
+                                            /*counter=*/buf_counter_,
+                                            /*residual_dest=*/hidden);
+        clReleaseMemObject(norm1);
+        if (!attn_out) return false;
+        if (attn_out != hidden) {
+            if (!element_add_inplace(queue, utils_program_, hidden, attn_out,
+                                     (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE)) {
+                clReleaseMemObject(attn_out);
+                return false;
+            }
+        }
+        clReleaseMemObject(attn_out);
+
+        cl_mem norm2 = post_attn_norm_[i]->forward(queue, hidden, seq_len);
+        if (!norm2) return false;
+
+        cl_mem mlp_out = mlp_[i]->forward(queue, norm2, seq_len, /*residual_dest=*/hidden);
+        clReleaseMemObject(norm2);
+        if (!mlp_out) return false;
+        if (mlp_out != hidden) {
+            if (!element_add_inplace(queue, utils_program_, hidden, mlp_out,
+                                     (size_t)seq_len * MODEL_CONFIG::HIDDEN_SIZE)) {
+                clReleaseMemObject(mlp_out);
+                return false;
+            }
+        }
+        clReleaseMemObject(mlp_out);
+    }
+
+    // 4) Final norm.
+    cl_mem norm_f = final_norm_->forward(queue, hidden, seq_len);
+    if (!norm_f) return false;
+
+    // 5) lm_head: pytorch_linear → buf_logits_.
+    if (!buf_logits_) {
+        const size_t bytes = (size_t)MODEL_CONFIG::VOCAB_SIZE * sizeof(nnopt_storage_t);
+        buf_logits_ = clCreateBuffer(cl_ctx_.context(), CL_MEM_READ_WRITE, bytes, nullptr, &err);
+        if (err != CL_SUCCESS || !buf_logits_) {
+            NNOPT_ERROR_FMT("forward_chained_enqueue: alloc buf_logits_ failed: %d", (int)err);
+            clReleaseMemObject(norm_f);
+            return false;
+        }
+        buf_logits_rows_ = 1;
+    }
+    if (!pytorch_linear(queue, /*M=*/1,
+                        /*N=*/MODEL_CONFIG::VOCAB_SIZE,
+                        /*K=*/MODEL_CONFIG::HIDDEN_SIZE,
+                        norm_f, w_lm_head_, buf_logits_)) {
+        clReleaseMemObject(norm_f);
+        return false;
+    }
+    clReleaseMemObject(norm_f);
+
+    // 6) Argmax. Writes int32 → argmax_out_buf_. NO host readback.
+    int N = MODEL_CONFIG::VOCAB_SIZE;
+    int num_partials = NUM_PARTIALS;
+    err = clSetKernelArg(argmax_partial_, 0, sizeof(cl_mem), &buf_logits_);
+    if (err == CL_SUCCESS) err = clSetKernelArg(argmax_partial_, 1, sizeof(cl_mem), &argmax_pv_buf_);
+    if (err == CL_SUCCESS) err = clSetKernelArg(argmax_partial_, 2, sizeof(cl_mem), &argmax_pi_buf_);
+    if (err == CL_SUCCESS) err = clSetKernelArg(argmax_partial_, 3, sizeof(int), &N);
+    if (err == CL_SUCCESS) err = clSetKernelArg(argmax_partial_, 4, sizeof(int), &num_partials);
+    if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("forward_chained_enqueue: argmax_partial setArg failed: %d", err);
+        return false;
+    }
+    {
+        size_t lws = 64;
+        size_t gws = (size_t)NUM_PARTIALS * lws;
+        err = nnopt_prof::enqueue(queue, argmax_partial_, 1, nullptr, &gws, &lws, 0, nullptr, nullptr);
+        if (err != CL_SUCCESS) {
+            NNOPT_ERROR_FMT("forward_chained_enqueue: argmax_partial enqueue failed: %d", err);
+            return false;
+        }
+    }
+    err = clSetKernelArg(argmax_finalize_, 0, sizeof(cl_mem), &argmax_pv_buf_);
+    if (err == CL_SUCCESS) err = clSetKernelArg(argmax_finalize_, 1, sizeof(cl_mem), &argmax_pi_buf_);
+    if (err == CL_SUCCESS) err = clSetKernelArg(argmax_finalize_, 2, sizeof(cl_mem), &argmax_out_buf_);
+    if (err == CL_SUCCESS) err = clSetKernelArg(argmax_finalize_, 3, sizeof(int), &num_partials);
+    if (err != CL_SUCCESS) {
+        NNOPT_ERROR_FMT("forward_chained_enqueue: argmax_finalize setArg failed: %d", err);
+        return false;
+    }
+    {
+        size_t lws = 64;
+        size_t gws = 64;
+        err = nnopt_prof::enqueue(queue, argmax_finalize_, 1, nullptr, &gws, &lws, 0, nullptr, nullptr);
+        if (err != CL_SUCCESS) {
+            NNOPT_ERROR_FMT("forward_chained_enqueue: argmax_finalize enqueue failed: %d", err);
+            return false;
+        }
+    }
+    return true;
+}
+
 std::vector<int32_t> Model::generate(
     const std::vector<int32_t>& prompt_ids,
     int max_new_tokens,
@@ -738,6 +900,100 @@ std::vector<int32_t> Model::generate(
     // decode step. Same kernels otherwise; same token IDs guaranteed.
     const bool greedy_path = (sampler_config.temperature <= 0.0f) &&
                              (sampler_config.repetition_penalty == 1.0f);
+
+    // ── Chained-decode fast path (Step 17) ──
+    // When greedy AND we have ≥2 decode steps to do, use the chained
+    // forward_chained_enqueue + ping-pong async readback pattern. The
+    // token id flows from the GPU argmax buffer directly into the next
+    // step's embedding (no host roundtrip), and host readback is
+    // overlapped with the next forward's enqueue.
+    //
+    // The first chained call needs argmax_out_buf_ already seeded with
+    // the first decode token. forward_greedy below does that — its sync
+    // readback also gives us the value to push into ids/generated.
+    //
+    // Disabled if NNOPT_RECORD=1 (recording path uses its own dispatch).
+    const char* nochain_env = std::getenv("NNOPT_NO_CHAIN");
+    const bool chain_enabled = greedy_path && (max_new_tokens > 2)
+                               && !(nochain_env && nochain_env[0] == '1')
+                               && !recordable_q_;
+
+    if (chain_enabled) {
+        // Step 1: seed argmax_out_buf_ with the first decode token by
+        // running forward_greedy once. This both produces the
+        // generated[0] token AND populates argmax_out_buf_ for the next
+        // call's embedding.
+        const int pos0 = (int)prompt_ids.size();
+        int32_t tok0 = forward_greedy(std::vector<int32_t>{next_token}, pos0);
+        if (tok0 < 0) {
+            NNOPT_ERROR("chained decode: seed forward_greedy failed");
+            return ids;
+        }
+        next_token = tok0;
+        ids.push_back(next_token);
+        generated.push_back(next_token);
+        if (on_token) on_token(next_token, ids);
+        bool eos_seen =
+            (sampler_config.eos_token_id >= 0 && next_token == sampler_config.eos_token_id);
+
+        // Step 2+: chained loop with 2-slot ping-pong async readback.
+        cl_command_queue queue = cl_ctx_.queue();
+        int32_t host_int[2] = {0, 0};
+        cl_event readback_event[2] = {nullptr, nullptr};
+        bool slot_pending[2] = {false, false};
+        int prev_slot = -1;
+
+        for (int i = 2; i < max_new_tokens && !eos_seen; i++) {
+            const int pos = (int)prompt_ids.size() + (i - 1);
+            const int cur_slot = i & 1;
+
+            if (!forward_chained_enqueue(pos)) {
+                NNOPT_ERROR("chained decode forward failed");
+                break;
+            }
+            cl_int rerr = clEnqueueReadBuffer(queue, argmax_out_buf_, CL_FALSE, 0,
+                                               sizeof(int32_t), &host_int[cur_slot],
+                                               0, nullptr, &readback_event[cur_slot]);
+            if (rerr != CL_SUCCESS) {
+                NNOPT_ERROR_FMT("chained async readback enqueue failed: %d", (int)rerr);
+                break;
+            }
+            slot_pending[cur_slot] = true;
+            clFlush(queue);
+
+            // Drain the previous iteration's readback (the token from one step ago).
+            if (prev_slot >= 0 && slot_pending[prev_slot]) {
+                clWaitForEvents(1, &readback_event[prev_slot]);
+                clReleaseEvent(readback_event[prev_slot]);
+                readback_event[prev_slot] = nullptr;
+                slot_pending[prev_slot] = false;
+                int32_t t = host_int[prev_slot];
+                ids.push_back(t);
+                generated.push_back(t);
+                if (on_token) on_token(t, ids);
+                if (sampler_config.eos_token_id >= 0 && t == sampler_config.eos_token_id) {
+                    eos_seen = true;
+                }
+            }
+            prev_slot = cur_slot;
+        }
+        // Drain the in-flight final readback.
+        if (prev_slot >= 0 && slot_pending[prev_slot]) {
+            clWaitForEvents(1, &readback_event[prev_slot]);
+            clReleaseEvent(readback_event[prev_slot]);
+            readback_event[prev_slot] = nullptr;
+            slot_pending[prev_slot] = false;
+            if (!eos_seen) {
+                int32_t t = host_int[prev_slot];
+                ids.push_back(t);
+                generated.push_back(t);
+                if (on_token) on_token(t, ids);
+            }
+        }
+        NNOPT_CHECKPOINT("generate() complete (chained)");
+        nnopt_prof::dump(cl_ctx_.queue());
+        return ids;
+    }
 
     for (int i = 1; i < max_new_tokens; i++) {
         const int pos = (int)prompt_ids.size() + (i - 1);

--- a/src/models/qwen2-5-0-5b/src/model.h
+++ b/src/models/qwen2-5-0-5b/src/model.h
@@ -42,6 +42,21 @@ public:
     // (temperature ≤ 0 AND repetition_penalty == 1.0).
     int32_t forward_greedy(const std::vector<int32_t>& input_ids, int start_pos);
 
+    // Chained-decode enqueue (Step 17): same as forward_greedy(seq=1) but
+    // (a) the embedding reads its token id directly from argmax_out_buf_ —
+    // no host roundtrip — and (b) NO synchronous readback at the end. The
+    // new token id is written to argmax_out_buf_ by argmax_finalize and
+    // is consumed by the NEXT call's embedding. Caller is responsible for
+    // (1) seeding argmax_out_buf_ with the first decode token before the
+    // first call, and (2) reading argmax_out_buf_ asynchronously to
+    // retrieve produced tokens. Returns false on enqueue error.
+    bool forward_chained_enqueue(int start_pos);
+
+    // Accessor for the device-side argmax output buffer. Used by the
+    // chained-decode loop in main.cpp to async-readback produced tokens
+    // and to seed the buffer with the first token.
+    cl_mem argmax_result_buffer() const { return argmax_out_buf_; }
+
     std::vector<int32_t> generate(
         const std::vector<int32_t>& prompt_ids,
         int max_new_tokens = 64,

--- a/src/models/qwen2-5-0-5b/src/opencl_context.cpp
+++ b/src/models/qwen2-5-0-5b/src/opencl_context.cpp
@@ -8,6 +8,9 @@
 #include <cstdint>
 #include <sys/stat.h>
 #include <dlfcn.h>
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#endif
 
 // ──────────────────────────────────────────────────────────────────────
 // Program binary cache — fixes the cold-start TTFT problem (~30 s
@@ -301,4 +304,101 @@ size_t OpenCLContext::local_mem_size() const {
     cl_ulong size;
     clGetDeviceInfo(device_, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(size), &size, nullptr);
     return (size_t)size;
+}
+
+std::string OpenCLContext::device_description() const {
+    auto str = [&](cl_device_info q) -> std::string {
+        char buf[512] = {0};
+        if (clGetDeviceInfo(device_, q, sizeof(buf), buf, nullptr) != CL_SUCCESS) return "?";
+        return std::string(buf);
+    };
+    auto u32 = [&](cl_device_info q) -> std::string {
+        cl_uint v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return "?";
+        return std::to_string(v);
+    };
+    auto u64_bytes = [&](cl_device_info q) -> cl_ulong {
+        cl_ulong v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return 0;
+        return v;
+    };
+
+    // Adreno's KGSL driver exposes the actual GPU model at /sys/class/kgsl/...
+    // Older driver builds return only "QUALCOMM Adreno(TM)" via CL_DEVICE_NAME
+    // (no chip number); splice the sysfs model in when CL_DEVICE_NAME lacks digits.
+    std::string name = device_name();
+    bool name_has_digit = false;
+    for (char c : name) if (c >= '0' && c <= '9') { name_has_digit = true; break; }
+    if (!name_has_digit) {
+        std::ifstream f("/sys/class/kgsl/kgsl-3d0/gpu_model");
+        std::string m;
+        if (f.is_open() && std::getline(f, m)) {
+            while (!m.empty() && (m.back() == '\n' || m.back() == '\r' || m.back() == ' ')) m.pop_back();
+            // "Adreno620v2" -> "Adreno 620v2"
+            size_t apos = m.find("Adreno");
+            if (apos != std::string::npos && apos + 6 < m.size() &&
+                m[apos + 6] >= '0' && m[apos + 6] <= '9') {
+                m.insert(apos + 6, " ");
+            }
+            const std::string tm_marker = "Adreno(TM)";
+            size_t tm = name.find(tm_marker);
+            if (!m.empty() && tm != std::string::npos) {
+                name.replace(tm, tm_marker.size(), m);
+            } else if (!m.empty()) {
+                name += " (" + m + ")";
+            }
+        }
+    }
+
+    // CL_DEVICE_VERSION is "OpenCL X.Y <impl details>" — keep just "X.Y".
+    std::string ver = str(CL_DEVICE_VERSION);
+    if (ver.rfind("OpenCL ", 0) == 0) {
+        size_t sp = ver.find(' ', 7);
+        ver = (sp == std::string::npos) ? ver.substr(7) : ver.substr(7, sp - 7);
+    }
+
+    // CL_DRIVER_VERSION on Adreno is a verbose build banner. The only piece
+    // that meaningfully changes between driver releases is the "Compiler EXXX..."
+    // token — extract it; fall back to first whitespace-token otherwise.
+    std::string drv = str(CL_DRIVER_VERSION);
+    {
+        size_t pos = drv.find("Compiler ");
+        if (pos != std::string::npos) drv = drv.substr(pos + 9);
+        size_t end = drv.find_first_of(" \t\r\n");
+        if (end != std::string::npos) drv = drv.substr(0, end);
+    }
+
+    cl_ulong gmem = u64_bytes(CL_DEVICE_GLOBAL_MEM_SIZE);
+    cl_ulong lmem = u64_bytes(CL_DEVICE_LOCAL_MEM_SIZE);
+    char gbuf[32], lbuf[32];
+    snprintf(gbuf, sizeof(gbuf), "%.1f GB", gmem / 1e9);
+    snprintf(lbuf, sizeof(lbuf), "%llu KB", (unsigned long long)(lmem / 1024));
+
+    // Android SoC model + platform codename. OpenCL exposes neither, so this
+    // is the only way to surface the actual chip (e.g. SM7250 / lito).
+    std::string soc;
+#ifdef __ANDROID__
+    {
+        char model[PROP_VALUE_MAX] = {0};
+        char board[PROP_VALUE_MAX] = {0};
+        __system_property_get("ro.soc.model", model);
+        __system_property_get("ro.board.platform", board);
+        if (model[0]) {
+            soc = model;
+            if (board[0]) soc += " (" + std::string(board) + ")";
+        } else if (board[0]) {
+            soc = board;
+        }
+    }
+#endif
+
+    std::ostringstream os;
+    os << name << "\n";
+    if (!soc.empty()) os << "  SoC:    " << soc << "\n";
+    os << "  Memory: " << gbuf << " global / " << lbuf << " local\n"
+       << "  CUs:    " << u32(CL_DEVICE_MAX_COMPUTE_UNITS) << "\n"
+       << "  Clock:  " << u32(CL_DEVICE_MAX_CLOCK_FREQUENCY) << " MHz\n"
+       << "  OpenCL: " << ver << "\n"
+       << "  Driver: " << drv;
+    return os.str();
 }

--- a/src/models/qwen2-5-0-5b/src/opencl_context.h
+++ b/src/models/qwen2-5-0-5b/src/opencl_context.h
@@ -23,6 +23,7 @@ public:
 
     // Device info
     std::string device_name() const;
+    std::string device_description() const;
     size_t max_work_group_size() const;
     size_t local_mem_size() const;
 

--- a/src/models/smollm2-135m-instruct/src/main.cpp
+++ b/src/models/smollm2-135m-instruct/src/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "Failed to initialize OpenCL" << std::endl;
         return 1;
     }
-    std::cerr << "Device: " << cl_ctx.device_name() << std::endl;
+    std::cerr << "Device: " << cl_ctx.device_description() << std::endl;
     NNOPT_CHECKPOINT("OpenCL initialized");
 
     // Load tokenizer (still needed for decoding output)
@@ -290,8 +290,6 @@ int main(int argc, char* argv[]) {
 
     // Generate
     NNOPT_CHECKPOINT("starting generation");
-    Timer timer;
-    timer.start();
 
     // Prefill clock starts now — excludes tokenize (see comment block above the
     // mark_inference_start() call for the full metric contract).
@@ -315,6 +313,16 @@ int main(int argc, char* argv[]) {
     size_t streamed_chars = 0;
     Model::TokenCallback on_token = nullptr;
     if (tokenizer_ok && stream_enabled) {
+        // Seed the stream buffer with the prompt so the user sees their input
+        // before the first generated token appears. Decoding through the
+        // tokenizer (rather than echoing argv[1]) gives round-trip parity and
+        // covers the chat-mode path where input_ids include ChatML wrapper
+        // tokens that aren't in the raw prompt string.
+        stream_buf.assign(input_ids.begin(), input_ids.end());
+        std::string text = tokenizer.decode(stream_buf);
+        std::fputs(text.c_str(), stdout);
+        std::fflush(stdout);
+        streamed_chars = text.size();
         on_token = [&](int32_t t) {
             stream_buf.push_back(t);
             std::string text = tokenizer.decode(stream_buf);
@@ -333,7 +341,6 @@ int main(int argc, char* argv[]) {
         std::fflush(stdout);
     }
     bench.mark_end();
-    double elapsed = timer.elapsed_ms();
     int gen_tokens = output_ids.size() - input_ids.size();
     NNOPT_CHECKPOINT("generation complete");
 
@@ -362,11 +369,6 @@ int main(int argc, char* argv[]) {
         }
         std::cout << std::endl;
     }
-
-    // Stats (human-readable summary — kept for backward compat with old parsers)
-    std::cerr << "Generated " << gen_tokens << " tokens in "
-              << elapsed << " ms ("
-              << (gen_tokens * 1000.0 / elapsed) << " tokens/sec)" << std::endl;
 
     // Structured baseline metrics for FinalizePort / README generation.
     bench.print_summary((int)input_ids.size(), gen_tokens);

--- a/src/models/smollm2-135m-instruct/src/opencl_context.cpp
+++ b/src/models/smollm2-135m-instruct/src/opencl_context.cpp
@@ -8,6 +8,9 @@
 #include <cstdint>
 #include <sys/stat.h>
 #include <dlfcn.h>
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#endif
 
 // ──────────────────────────────────────────────────────────────────────
 // Program binary cache — fixes the cold-start TTFT problem (~30 s
@@ -300,4 +303,101 @@ size_t OpenCLContext::local_mem_size() const {
     cl_ulong size;
     clGetDeviceInfo(device_, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(size), &size, nullptr);
     return (size_t)size;
+}
+
+std::string OpenCLContext::device_description() const {
+    auto str = [&](cl_device_info q) -> std::string {
+        char buf[512] = {0};
+        if (clGetDeviceInfo(device_, q, sizeof(buf), buf, nullptr) != CL_SUCCESS) return "?";
+        return std::string(buf);
+    };
+    auto u32 = [&](cl_device_info q) -> std::string {
+        cl_uint v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return "?";
+        return std::to_string(v);
+    };
+    auto u64_bytes = [&](cl_device_info q) -> cl_ulong {
+        cl_ulong v = 0;
+        if (clGetDeviceInfo(device_, q, sizeof(v), &v, nullptr) != CL_SUCCESS) return 0;
+        return v;
+    };
+
+    // Adreno's KGSL driver exposes the actual GPU model at /sys/class/kgsl/...
+    // Older driver builds return only "QUALCOMM Adreno(TM)" via CL_DEVICE_NAME
+    // (no chip number); splice the sysfs model in when CL_DEVICE_NAME lacks digits.
+    std::string name = device_name();
+    bool name_has_digit = false;
+    for (char c : name) if (c >= '0' && c <= '9') { name_has_digit = true; break; }
+    if (!name_has_digit) {
+        std::ifstream f("/sys/class/kgsl/kgsl-3d0/gpu_model");
+        std::string m;
+        if (f.is_open() && std::getline(f, m)) {
+            while (!m.empty() && (m.back() == '\n' || m.back() == '\r' || m.back() == ' ')) m.pop_back();
+            // "Adreno620v2" -> "Adreno 620v2"
+            size_t apos = m.find("Adreno");
+            if (apos != std::string::npos && apos + 6 < m.size() &&
+                m[apos + 6] >= '0' && m[apos + 6] <= '9') {
+                m.insert(apos + 6, " ");
+            }
+            const std::string tm_marker = "Adreno(TM)";
+            size_t tm = name.find(tm_marker);
+            if (!m.empty() && tm != std::string::npos) {
+                name.replace(tm, tm_marker.size(), m);
+            } else if (!m.empty()) {
+                name += " (" + m + ")";
+            }
+        }
+    }
+
+    // CL_DEVICE_VERSION is "OpenCL X.Y <impl details>" — keep just "X.Y".
+    std::string ver = str(CL_DEVICE_VERSION);
+    if (ver.rfind("OpenCL ", 0) == 0) {
+        size_t sp = ver.find(' ', 7);
+        ver = (sp == std::string::npos) ? ver.substr(7) : ver.substr(7, sp - 7);
+    }
+
+    // CL_DRIVER_VERSION on Adreno is a verbose build banner. The only piece
+    // that meaningfully changes between driver releases is the "Compiler EXXX..."
+    // token — extract it; fall back to first whitespace-token otherwise.
+    std::string drv = str(CL_DRIVER_VERSION);
+    {
+        size_t pos = drv.find("Compiler ");
+        if (pos != std::string::npos) drv = drv.substr(pos + 9);
+        size_t end = drv.find_first_of(" \t\r\n");
+        if (end != std::string::npos) drv = drv.substr(0, end);
+    }
+
+    cl_ulong gmem = u64_bytes(CL_DEVICE_GLOBAL_MEM_SIZE);
+    cl_ulong lmem = u64_bytes(CL_DEVICE_LOCAL_MEM_SIZE);
+    char gbuf[32], lbuf[32];
+    snprintf(gbuf, sizeof(gbuf), "%.1f GB", gmem / 1e9);
+    snprintf(lbuf, sizeof(lbuf), "%llu KB", (unsigned long long)(lmem / 1024));
+
+    // Android SoC model + platform codename. OpenCL exposes neither, so this
+    // is the only way to surface the actual chip (e.g. SM7250 / lito).
+    std::string soc;
+#ifdef __ANDROID__
+    {
+        char model[PROP_VALUE_MAX] = {0};
+        char board[PROP_VALUE_MAX] = {0};
+        __system_property_get("ro.soc.model", model);
+        __system_property_get("ro.board.platform", board);
+        if (model[0]) {
+            soc = model;
+            if (board[0]) soc += " (" + std::string(board) + ")";
+        } else if (board[0]) {
+            soc = board;
+        }
+    }
+#endif
+
+    std::ostringstream os;
+    os << name << "\n";
+    if (!soc.empty()) os << "  SoC:    " << soc << "\n";
+    os << "  Memory: " << gbuf << " global / " << lbuf << " local\n"
+       << "  CUs:    " << u32(CL_DEVICE_MAX_COMPUTE_UNITS) << "\n"
+       << "  Clock:  " << u32(CL_DEVICE_MAX_CLOCK_FREQUENCY) << " MHz\n"
+       << "  OpenCL: " << ver << "\n"
+       << "  Driver: " << drv;
+    return os.str();
 }

--- a/src/models/smollm2-135m-instruct/src/opencl_context.h
+++ b/src/models/smollm2-135m-instruct/src/opencl_context.h
@@ -23,6 +23,7 @@ public:
 
     // Device info
     std::string device_name() const;
+    std::string device_description() const;
     size_t max_work_group_size() const;
     size_t local_mem_size() const;
 


### PR DESCRIPTION
OpenELM-270M: K-specialized GEMV variants (_k768/_k1280/_k1536) and a coalesced generic _no4 path lift decode from 4.60 to 10.59 tok/s. Adds fused-residual out_proj, chained enqueue forward, persistent logits buffer, and a per-kernel cl_event profiler gated on NNOPT_KERNEL_PROFILE.